### PR TITLE
fix(components): align service-card and button styling for #33

### DIFF
--- a/src/components/ServiceCard.astro
+++ b/src/components/ServiceCard.astro
@@ -17,19 +17,18 @@ const { title, description, outcome, variant = 'default' } = Astro.props;
       </div>
     )
   }
-  <h3><span>{title}</span></h3>
+  <h3>{title}</h3>
   <p>{description}</p>
   <p class="outcome"><strong>Typisk resultat:</strong> {outcome}</p>
 </article>
 
 <style>
   .service-card {
-    border: 2px solid var(--color-border);
+    border: 1px solid var(--color-border);
     background: var(--color-surface);
     padding: 1.5rem;
-    box-shadow: var(--shadow);
     display: grid;
-    gap: 0.75rem;
+    gap: 1rem;
   }
 
   .service-card.surface-low {
@@ -37,27 +36,19 @@ const { title, description, outcome, variant = 'default' } = Astro.props;
   }
 
   .service-icon {
-    inline-size: 2.5rem;
-    block-size: 2.5rem;
-    border: 2px solid var(--color-border);
-    background: var(--color-accent);
+    inline-size: 2rem;
+    block-size: 2rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: var(--fs-heading-xs);
+    color: var(--color-primary);
+    font-size: var(--fs-heading-s);
     font-weight: var(--font-weight-bold);
   }
 
   .service-card h3 {
     font-size: var(--fs-heading-xs);
     line-height: var(--line-height-m);
-  }
-
-  .service-card h3 span {
-    background-color: var(--color-accent);
-    padding: 0.25rem 0.5rem;
-    box-decoration-break: clone;
-    -webkit-box-decoration-break: clone;
   }
 
   .service-card p {

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -6,8 +6,8 @@
   padding-block: calc(1.25rem - var(--border-width));
   padding-inline: calc(2.1875rem - var(--border-width));
   font-size: var(--fs-label-l);
-  font-weight: var(--font-weight-bold);
-  letter-spacing: 0.08em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   line-height: 1;
   border: var(--border-width) solid transparent;


### PR DESCRIPTION
## Summary
- Reapply the #33 delta on a dedicated branch instead of committing directly to `overhaul`
- Flatten `ServiceCard` visuals per #44: remove heavy shadow treatment, reduce border weight, remove accent title highlight
- Tune button label typography per #41: semibold weight and 0.05em tracking

## Test plan
- [x] `pnpm check`
- [x] `pnpm build`
- [x] Verified no lints in edited files

## Notes
- The previous direct commit to `overhaul` was reverted on `overhaul` (`d3a9c16`).
- This PR now contains the same intended changes for review before merge into `overhaul`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes to component and shared button CSS; main risk is unintended layout/contrast regressions in affected UI elements.
> 
> **Overview**
> Flattens `ServiceCard` presentation by removing the accent-highlighted title treatment, dropping the heavy shadow, reducing border weight, and slightly adjusting spacing.
> 
> Updates `ServiceCard` icon styling (smaller size and new color/typography) and tweaks global `.button` label typography to use semibold weight with tighter letter spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15267765bff0ffd2c31255e6c9d58526c43894c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->