### PR TITLE
epic(#28): close out decorative utilities and finalize component refresh

### DIFF
--- a/component-consumer-map.md
+++ b/component-consumer-map.md
@@ -23,4 +23,4 @@ This map captures concrete downstream consumers for all `#28` component-system t
 | `CategoryFilter`                            | `src/pages/prosjekter/index.astro`                                                                       | Implemented                                      |
 | `QuoteBlock`                                | `src/pages/om-kynd.astro`                                                                                | Implemented                                      |
 | `JobCard`                                   | `src/pages/bli-en-av-oss.astro`                                                                          | Implemented                                      |
-| Decorative pattern utilities (`u-pattern*`) | `src/components/HeroLayout.astro`                                                                        | Implemented (API naming differs from issue text) |
+| Decorative pattern utilities (`.pattern-*` + `u-pattern*`) | `src/components/HeroLayout.astro`                                                                        | Implemented |

--- a/component-consumer-map.md
+++ b/component-consumer-map.md
@@ -16,11 +16,11 @@ This map captures concrete downstream consumers for all `#28` component-system t
 
 ## New Components Scope (#34)
 
-| Component/Utility                           | Primary Consumer(s)                                                                                      | Status                                           |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `NumberedConceptCard`                       | `src/pages/index.astro` ("Hva Kynd er" cards), `src/pages/om-kynd.astro`                                 | Implemented                                      |
-| `Badge`                                     | `src/components/CategoryFilter.astro`, `src/components/QuoteBlock.astro`, `src/components/JobCard.astro` | Implemented                                      |
-| `CategoryFilter`                            | `src/pages/prosjekter/index.astro`                                                                       | Implemented                                      |
-| `QuoteBlock`                                | `src/pages/om-kynd.astro`                                                                                | Implemented                                      |
-| `JobCard`                                   | `src/pages/bli-en-av-oss.astro`                                                                          | Implemented                                      |
+| Component/Utility                                          | Primary Consumer(s)                                                                                      | Status      |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------- |
+| `NumberedConceptCard`                                      | `src/pages/index.astro` ("Hva Kynd er" cards), `src/pages/om-kynd.astro`                                 | Implemented |
+| `Badge`                                                    | `src/components/CategoryFilter.astro`, `src/components/QuoteBlock.astro`, `src/components/JobCard.astro` | Implemented |
+| `CategoryFilter`                                           | `src/pages/prosjekter/index.astro`                                                                       | Implemented |
+| `QuoteBlock`                                               | `src/pages/om-kynd.astro`                                                                                | Implemented |
+| `JobCard`                                                  | `src/pages/bli-en-av-oss.astro`                                                                          | Implemented |
 | Decorative pattern utilities (`.pattern-*` + `u-pattern*`) | `src/components/HeroLayout.astro`                                                                        | Implemented |

--- a/component-system.md
+++ b/component-system.md
@@ -63,19 +63,19 @@ Tokenized CSS used across multiple components.
 
 ## Issue-to-Component Mapping
 
-| Issue | Parent | Scope                                     | Primary Files                                                                             | Current Code Status                          |
-| ----- | ------ | ----------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------- |
-| #41   | #33    | Button/ButtonLink visual restyle          | `src/styles/button.css`, `src/components/Button.astro`, `src/components/ButtonLink.astro` | Implemented                                  |
-| #42   | #33    | Hero tagline + size support               | `src/components/HeroSection.astro`, `src/components/HeroLayout.astro`                     | Implemented                                  |
-| #43   | #33    | `ContactCTA` + `FullBleed` variants       | `src/components/ContactCTA.astro`, `src/components/layout/FullBleed.astro`                | Implemented                                  |
-| #44   | #33    | `ServiceCard` restyle + icon slot         | `src/components/ServiceCard.astro`                                                        | Implemented                                  |
-| #45   | #33    | Header/Footer token and frosted treatment | `src/components/Header.astro`, `src/components/Footer.astro`                              | Implemented                                  |
-| #46   | #34    | `NumberedConceptCard`                     | `src/components/NumberedConceptCard.astro`                                                | Implemented                                  |
-| #47   | #34    | `Badge` component                         | `src/components/Badge.astro`                                                              | Implemented                                  |
-| #48   | #34    | `CategoryFilter` component                | `src/components/CategoryFilter.astro`                                                     | Implemented                                  |
-| #49   | #34    | `QuoteBlock` component                    | `src/components/QuoteBlock.astro`                                                         | Implemented                                  |
-| #50   | #34    | `JobCard` component                       | `src/components/JobCard.astro`                                                            | Implemented                                  |
-| #51   | #34    | Decorative pattern utilities              | `src/styles/decorative-pattern.css`, `src/styles/utilities.css`                           | Implemented                                   |
+| Issue | Parent | Scope                                     | Primary Files                                                                             | Current Code Status |
+| ----- | ------ | ----------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
+| #41   | #33    | Button/ButtonLink visual restyle          | `src/styles/button.css`, `src/components/Button.astro`, `src/components/ButtonLink.astro` | Implemented         |
+| #42   | #33    | Hero tagline + size support               | `src/components/HeroSection.astro`, `src/components/HeroLayout.astro`                     | Implemented         |
+| #43   | #33    | `ContactCTA` + `FullBleed` variants       | `src/components/ContactCTA.astro`, `src/components/layout/FullBleed.astro`                | Implemented         |
+| #44   | #33    | `ServiceCard` restyle + icon slot         | `src/components/ServiceCard.astro`                                                        | Implemented         |
+| #45   | #33    | Header/Footer token and frosted treatment | `src/components/Header.astro`, `src/components/Footer.astro`                              | Implemented         |
+| #46   | #34    | `NumberedConceptCard`                     | `src/components/NumberedConceptCard.astro`                                                | Implemented         |
+| #47   | #34    | `Badge` component                         | `src/components/Badge.astro`                                                              | Implemented         |
+| #48   | #34    | `CategoryFilter` component                | `src/components/CategoryFilter.astro`                                                     | Implemented         |
+| #49   | #34    | `QuoteBlock` component                    | `src/components/QuoteBlock.astro`                                                         | Implemented         |
+| #50   | #34    | `JobCard` component                       | `src/components/JobCard.astro`                                                            | Implemented         |
+| #51   | #34    | Decorative pattern utilities              | `src/styles/decorative-pattern.css`, `src/styles/utilities.css`                           | Implemented         |
 
 ## Decorative Utility Compatibility
 

--- a/component-system.md
+++ b/component-system.md
@@ -75,11 +75,12 @@ Tokenized CSS used across multiple components.
 | #48   | #34    | `CategoryFilter` component                | `src/components/CategoryFilter.astro`                                                     | Implemented                                  |
 | #49   | #34    | `QuoteBlock` component                    | `src/components/QuoteBlock.astro`                                                         | Implemented                                  |
 | #50   | #34    | `JobCard` component                       | `src/components/JobCard.astro`                                                            | Implemented                                  |
-| #51   | #34    | Decorative pattern utilities              | `src/styles/decorative-pattern.css`, `src/styles/utilities.css`                           | Implemented (naming differs from issue text) |
+| #51   | #34    | Decorative pattern utilities              | `src/styles/decorative-pattern.css`, `src/styles/utilities.css`                           | Implemented                                   |
 
-## Notable Delta
+## Decorative Utility Compatibility
 
-- Issue `#51` describes `.pattern-dots` and `.pattern-lines`. The implemented utility pattern API currently uses `.u-pattern` and `.u-pattern--waves` in `src/styles/decorative-pattern.css` and is consumed by `HeroLayout`. This is functionally delivered as a reusable decorative utility, but naming does not exactly match the original text.
+- Issue `#51` acceptance is now satisfied with canonical `.pattern-dots` and `.pattern-lines` utilities in `src/styles/decorative-pattern.css`.
+- Legacy `.u-pattern` and `.u-pattern--waves` utilities remain available for backwards compatibility.
 
 ## Dependency Graph
 

--- a/src/styles/decorative-pattern.css
+++ b/src/styles/decorative-pattern.css
@@ -1,18 +1,21 @@
-.u-pattern {
+:where(.u-pattern, .pattern-dots, .pattern-lines) {
   position: relative;
   isolation: isolate;
 }
 
-.u-pattern::after {
+:where(.u-pattern, .pattern-dots, .pattern-lines)::after {
   content: '';
   position: absolute;
   inset: auto -2rem -2rem auto;
   width: clamp(10rem, 28vw, 20rem);
   aspect-ratio: 1099 / 755;
-  background: currentColor;
-  opacity: 0.07;
   pointer-events: none;
   z-index: -1;
+}
+
+.u-pattern::after {
+  background: currentColor;
+  opacity: 0.07;
   -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
   -webkit-mask-size: contain;
@@ -24,4 +27,20 @@
 .u-pattern--waves::after {
   -webkit-mask-image: url('/patterns/pattern-1.svg');
   mask-image: url('/patterns/pattern-1.svg');
+}
+
+.pattern-dots::after {
+  --pattern-color: color-mix(in srgb, var(--color-border) 40%, transparent);
+  background-image: radial-gradient(circle, var(--pattern-color) 1px, transparent 1.5px);
+  background-size: 0.75rem 0.75rem;
+  opacity: 1;
+}
+
+.pattern-lines::after {
+  --pattern-color: color-mix(in srgb, var(--color-border) 35%, transparent);
+  background-image:
+    linear-gradient(to right, var(--pattern-color) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--pattern-color) 1px, transparent 1px);
+  background-size: 1rem 1rem;
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add canonical decorative utility classes `.pattern-dots` and `.pattern-lines` in shared styles while preserving legacy `.u-pattern*` behavior for backwards compatibility
- align component-system tracking docs so `#51` is represented as delivered without naming-mismatch caveats
- keep implementation DRY and architecture-consistent by extending shared tokenized CSS utilities instead of adding page-local pattern styles

## Test plan
- [x] `pnpm check`
- [x] `pnpm build`
- [ ] Manual visual check of hero decorative treatment

## Issue closure
- Closes #51
- Completes #34 scope for decorative utilities
- Enables final closeout of #28 after merge

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new CSS utility classes and updates documentation; potential impact is limited to decorative styling if selectors conflict or visuals change.
> 
> **Overview**
> Adds canonical decorative utility classes `pattern-dots` and `pattern-lines` in `src/styles/decorative-pattern.css`, sharing positioning/`::after` scaffolding with existing `.u-pattern` while preserving `.u-pattern--waves` for backwards compatibility.
> 
> Updates `component-system.md` and `component-consumer-map.md` to reflect the finalized naming/acceptance for issue `#51` (removing prior naming-mismatch caveats and documenting legacy compatibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5220b76a91874d928dc33c8e803d47f44fa97c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->