### PR TITLE
feat(shared): add reusable page list and teaser patterns

### DIFF
--- a/src/components/TeaserCard.astro
+++ b/src/components/TeaserCard.astro
@@ -1,0 +1,45 @@
+---
+export type Props = {
+  title: string;
+  href: string;
+  description?: string;
+  tone?: 'secondary' | 'secondary-shade';
+};
+
+const { title, href, description, tone = 'secondary-shade' } = Astro.props;
+---
+
+<article class:list={['teaser-card', `teaser-card--${tone}`]}>
+  <a href={href}>{title}</a>
+  {description && <p>{description}</p>}
+</article>
+
+<style>
+  .teaser-card {
+    border: 2px solid var(--color-primary);
+    padding: 1rem;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .teaser-card--secondary {
+    background: var(--color-secondary);
+  }
+
+  .teaser-card--secondary-shade {
+    background: var(--color-secondary-shade);
+  }
+
+  a {
+    font-size: var(--fs-heading-xs);
+    width: fit-content;
+    background-color: var(--color-accent);
+    color: var(--color-primary);
+    padding: 0.2rem 0.4rem;
+  }
+
+  p {
+    margin: 0;
+    font-size: var(--fs-body-s);
+  }
+</style>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -9,3 +9,30 @@
   white-space: nowrap;
   border-width: 0;
 }
+
+.u-list-disc {
+  list-style: disc;
+  padding-inline-start: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  font-size: var(--fs-body-m);
+}
+
+.u-grid-cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.u-grid-cards--2 {
+  @media (--md) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+}
+
+.u-grid-cards--3 {
+  @media (--md) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `TeaserCard` component for accent-link teaser blocks used across page rebuilds
- add shared list/grid utility classes in `utilities.css` to reduce repeated page-local section CSS
- prepare a DRY baseline for issue #29 child page rebuild PRs

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #29

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adds a new reusable Astro component and a few CSS utility classes without touching data, routing, or security-sensitive logic.
> 
> **Overview**
> Adds a new reusable `TeaserCard.astro` component for consistent teaser/link blocks, with optional description text and a configurable background tone.
> 
> Extends `utilities.css` with shared `.u-list-disc` and responsive `.u-grid-cards` utilities (2- and 3-column variants) to standardize common list and card-grid layouts across pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a69f446230a0aaefff19cdaaec2f264d681dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->