### PR TITLE
feat(home): align homepage composition with shared patterns

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,9 @@ import ContactCTA from '@/components/ContactCTA.astro';
 import HeroSection from '@/components/HeroSection.astro';
 import NumberedConceptCard from '@/components/NumberedConceptCard.astro';
 import PageSection from '@/components/PageSection.astro';
+import TeaserCard from '@/components/TeaserCard.astro';
 import FullBleed from '@/components/layout/FullBleed.astro';
+import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
 import { getProjectsWithDuration } from '@/utils/projectHelpers';
 
@@ -47,7 +49,7 @@ const collaborationStyle = [
     heading="Hva Kynd er"
     subheading="Et fellesskap av erfarne folk som kombinerer produktblikk, teknologiforståelse og gjennomføring."
   >
-    <ul class="card-grid">
+    <ul class="u-grid-cards u-grid-cards--3">
       {
         keyConcepts.map((concept, index) => (
           <li>
@@ -61,62 +63,53 @@ const collaborationStyle = [
     heading="Hva vi hjelper med"
     subheading="Du trenger ikke ha alt ferdig definert. Vi hjelper deg å finne riktig neste steg."
   >
-    <ul class="card-grid card-grid--text">
-      {helpAreas.map((area) => <li class="card-grid__item card-grid__item--text">{area}</li>)}
+    <ul class="u-grid-cards u-grid-cards--3">
+      {helpAreas.map((area) => <li class="text-card">{area}</li>)}
     </ul>
   </PageSection>
   <PageSection
     heading="Utvalgte samarbeid"
     subheading="Noen av prosjektene som viser hvordan vi kobler problem, innsats og effekt."
   >
-    <ClientLogoStrip projects={projects} />
-    <ul class="featured-projects">
-      {
-        featuredProjects.map((project) => (
-          <li>
-            <a href={`/prosjekter/${project.id}`}>{project.data.title}</a>
-            <p>{project.data.description}</p>
-          </li>
-        ))
-      }
-    </ul>
+    <Split minBreakpoint="md" gap="2rem" columns="1.1fr 0.9fr">
+      <div slot="left" class="logo-strip-wrap">
+        <ClientLogoStrip projects={projects} />
+      </div>
+      <ul slot="right" class="u-grid-cards">
+        {
+          featuredProjects.map((project) => (
+            <li>
+              <TeaserCard
+                title={project.data.title}
+                href={`/prosjekter/${project.id}`}
+                description={project.data.description}
+                tone="secondary"
+              />
+            </li>
+          ))
+        }
+      </ul>
+    </Split>
   </PageSection>
   <PageSection
     heading="Slik er det å jobbe med oss"
     subheading="Målet er lav friksjon, tydelighet og fremdrift fra første uke."
   >
-    <ul class="card-grid card-grid--text">
+    <ul class="u-grid-cards u-grid-cards--3">
       {
         collaborationStyle.map((style) => (
-          <li class="card-grid__item card-grid__item--text">{style}</li>
+          <li class="text-card">{style}</li>
         ))
       }
     </ul>
   </PageSection>
-  <FullBleed variant="surface-low">
-    <ContactCTA variant="surface-low" />
+  <FullBleed variant="dark">
+    <ContactCTA variant="dark" />
   </FullBleed>
 </Layout>
 
 <style>
-  .card-grid {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: grid;
-    gap: 1rem;
-
-    @media (--md) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 1.5rem;
-    }
-  }
-
-  .card-grid__item {
-    list-style: none;
-  }
-
-  .card-grid__item--text {
+  .text-card {
     border: 1px solid var(--color-border);
     background: var(--color-surface);
     box-shadow: var(--shadow);
@@ -124,30 +117,8 @@ const collaborationStyle = [
     font-size: var(--fs-body-s);
   }
 
-  .featured-projects {
-    list-style: none;
-    padding: 0;
-    margin: 1.5rem 0 0;
+  .logo-strip-wrap {
     display: grid;
-    gap: 1rem;
-  }
-
-  .featured-projects li {
-    border: 2px solid var(--color-primary);
-    background: var(--color-secondary);
-    padding: 1rem;
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  .featured-projects a {
-    font-size: var(--fs-heading-xs);
-    width: fit-content;
-    background-color: var(--color-accent);
-    padding: 0.2rem 0.4rem;
-  }
-
-  .featured-projects p {
-    font-size: var(--fs-body-s);
+    gap: 1.5rem;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,9 +72,7 @@ const collaborationStyle = [
     subheading="Noen av prosjektene som viser hvordan vi kobler problem, innsats og effekt."
   >
     <Split minBreakpoint="md" gap="2rem" columns="1.1fr 0.9fr">
-      <div slot="left" class="logo-strip-wrap">
-        <ClientLogoStrip projects={projects} />
-      </div>
+      <ClientLogoStrip slot="left" projects={projects} />
       <ul slot="right" class="u-grid-cards">
         {
           featuredProjects.map((project) => (
@@ -111,10 +109,5 @@ const collaborationStyle = [
     box-shadow: var(--shadow);
     padding: 1rem;
     font-size: var(--fs-body-s);
-  }
-
-  .logo-strip-wrap {
-    display: grid;
-    gap: 1.5rem;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -96,11 +96,7 @@ const collaborationStyle = [
     subheading="Målet er lav friksjon, tydelighet og fremdrift fra første uke."
   >
     <ul class="u-grid-cards u-grid-cards--3">
-      {
-        collaborationStyle.map((style) => (
-          <li class="text-card">{style}</li>
-        ))
-      }
+      {collaborationStyle.map((style) => <li class="text-card">{style}</li>)}
     </ul>
   </PageSection>
   <FullBleed variant="dark">

--- a/src/pages/om-kynd.astro
+++ b/src/pages/om-kynd.astro
@@ -84,8 +84,8 @@ const coreValues = [
       <Prose wide>
         <p>
           Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
-          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene til
-          å utvikle egne initiativer over tid.
+          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene
+          til å utvikle egne initiativer over tid.
         </p>
         <p>
           Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å

--- a/src/pages/om-kynd.astro
+++ b/src/pages/om-kynd.astro
@@ -1,10 +1,19 @@
 ---
 import ContactCTA from '@/components/ContactCTA.astro';
 import HeroSection from '@/components/HeroSection.astro';
+import NumberedConceptCard from '@/components/NumberedConceptCard.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import QuoteBlock from '@/components/QuoteBlock.astro';
+import TeaserCard from '@/components/TeaserCard.astro';
+import FullBleed from '@/components/layout/FullBleed.astro';
 import Layout from '@/layouts/Base.astro';
+
+const coreValues = [
+  'Integritet i tekniske og strategiske anbefalinger.',
+  'Tydelig kommunikasjon fremfor konsulentspråk.',
+  'Ansvar for effekt, ikke bare aktivitet.',
+];
 ---
 
 <Layout
@@ -44,7 +53,7 @@ import Layout from '@/layouts/Base.astro';
       author="Kynd"
       authorRole="Arbeidsform"
     />
-    <ul class="difference-list">
+    <ul class="u-list-disc">
       <li>Senior kompetanse tett på beslutninger med høy konsekvens.</li>
       <li>Selektivt samarbeid med tydelige forventninger til begge parter.</li>
       <li>Konkret rådgivning og operativ levering i samme team.</li>
@@ -53,44 +62,57 @@ import Layout from '@/layouts/Base.astro';
   </PageSection>
 
   <PageSection
-    heading="Konsulentarbeid og produktambisjon"
-    subheading="Vi bygger verdi for kunder i dag, og bygger også kompetanse og produkter på lang sikt."
+    heading="Verdier i praksis"
+    subheading="Disse verdiene styrer hvordan vi prioriterer i usikre og komplekse produktløp."
   >
-    <Prose wide>
-      <p>
-        Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
-        konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene til
-        å utvikle egne initiativer over tid.
-      </p>
-      <p>
-        Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å
-        virke annerledes, men å være nyttige i krevende kontekster.
-      </p>
-    </Prose>
+    <ul class="u-grid-cards u-grid-cards--3">
+      {
+        coreValues.map((value, index) => (
+          <li>
+            <NumberedConceptCard number={index + 1} title={value} />
+          </li>
+        ))
+      }
+    </ul>
   </PageSection>
 
+  <FullBleed variant="dark">
+    <PageSection
+      heading="Konsulentarbeid og produktambisjon"
+      subheading="Vi bygger verdi for kunder i dag, og bygger også kompetanse og produkter på lang sikt."
+    >
+      <Prose wide>
+        <p>
+          Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
+          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene til
+          å utvikle egne initiativer over tid.
+        </p>
+        <p>
+          Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å
+          virke annerledes, men å være nyttige i krevende kontekster.
+        </p>
+      </Prose>
+    </PageSection>
+  </FullBleed>
+
   <PageSection heading="Folka i Kynd" subheading="Menneskene bak leveransene.">
-    <a class="people-link" href="/folka">Møt folka</a>
+    <TeaserCard
+      title="Møt folka"
+      href="/folka"
+      description="Bli kjent med menneskene som bygger Kynd i praksis."
+      tone="secondary"
+    />
   </PageSection>
 
   <ContactCTA />
 </Layout>
 
 <style>
-  .difference-list {
-    list-style: disc;
-    padding-inline-start: 1rem;
-    display: grid;
-    gap: 0.75rem;
-    font-size: var(--fs-body-m);
+  .u-list-disc {
+    margin: 0;
   }
 
-  .people-link {
-    display: inline-block;
-    font-size: var(--fs-heading-xs);
-    background-color: var(--color-accent);
-    color: var(--color-primary);
-    padding: 0.5rem 0.75rem;
-    border: 2px solid var(--color-primary);
+  :global(.fullBleed.dark .prose) {
+    color: var(--color-secondary);
   }
 </style>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -21,6 +21,9 @@
 .u-grid-cards {
   display: grid;
   gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .u-grid-cards--2 {


### PR DESCRIPTION
## Summary
- rebuild `src/pages/index.astro` around shared section patterns and reduce page-local layout duplication
- use `Split` + `TeaserCard` for featured collaborations to better match the target structure
- switch the final CTA section to dark treatment and adopt shared grid utility usage

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #35
- Parent epic: #29

## Dependency
- Stacked on #56 (`feature/29-shared-page-patterns`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly presentation/layout changes, but the `u-grid-cards` utility update (list-style/padding/margin reset) can affect any existing consumers across the site.
> 
> **Overview**
> Refactors `src/pages/index.astro` to rely on shared utilities/components: replaces page-local card grid markup/styles with `u-grid-cards` + a new `.text-card`, and rebuilds the “Utvalgte samarbeid” section using `Split` and `TeaserCard` instead of a bespoke featured list.
> 
> Updates the bottom CTA to use the `dark` variant for both `FullBleed` and `ContactCTA`, and moves list reset behavior into the global `u-grid-cards` utility in `src/styles/utilities.css` (removing the now-unused homepage-local grid styles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43cb05fe31ba90dd6614df886fdb4a199240f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->