### PR TITLE
feat(services): rebuild services sections with shared patterns

### DIFF
--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -4,6 +4,8 @@ import FitSection from '@/components/FitSection.astro';
 import HeroSection from '@/components/HeroSection.astro';
 import PageSection from '@/components/PageSection.astro';
 import ServiceCard from '@/components/ServiceCard.astro';
+import FullBleed from '@/components/layout/FullBleed.astro';
+import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
 
 const services = [
@@ -93,7 +95,7 @@ const collaborationConsequences = [
     heading="Hva vi faktisk gjør"
     subheading="Vi går inn der erfarne folk gir størst forskjell, både i leveranse og retning."
   >
-    <div class="services-grid">
+    <div class="u-grid-cards u-grid-cards--2">
       {
         services.map((service) => (
           <ServiceCard
@@ -113,12 +115,14 @@ const collaborationConsequences = [
     heading="Slik leverer vi"
     subheading="Arbeidsformen er en del av tjenesten. Vi utfordrer tidlig, prioriterer hardt og tar ansvar for konsekvensene."
   >
-    <ul class="principles">
-      {operatingPrinciples.map((item) => <li>{item}</li>)}
-    </ul>
-    <ul class="consequences">
-      {collaborationConsequences.map((item) => <li>{item}</li>)}
-    </ul>
+    <Split minBreakpoint="md" gap="2rem">
+      <ul slot="left" class="u-list-disc">
+        {operatingPrinciples.map((item) => <li>{item}</li>)}
+      </ul>
+      <ul slot="right" class="u-list-disc">
+        {collaborationConsequences.map((item) => <li>{item}</li>)}
+      </ul>
+    </Split>
   </PageSection>
 
   <PageSection
@@ -128,34 +132,13 @@ const collaborationConsequences = [
     <FitSection fit={fit} noFit={noFit} />
   </PageSection>
 
-  <ContactCTA variant="dark" />
+  <FullBleed variant="surface-low">
+    <ContactCTA variant="dark" />
+  </FullBleed>
 </Layout>
 
 <style>
-  .services-grid {
-    display: grid;
-    gap: 1rem;
-
-    @media (--md) {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 1.5rem;
-    }
-  }
-
-  .consequences {
-    list-style: disc;
-    padding-inline-start: 1rem;
-    display: grid;
-    gap: 0.75rem;
-    font-size: var(--fs-body-m);
-    margin-block-start: 1rem;
-  }
-
-  .principles {
-    list-style: disc;
-    padding-inline-start: 1rem;
-    display: grid;
-    gap: 0.75rem;
-    font-size: var(--fs-body-m);
+  .u-list-disc {
+    margin: 0;
   }
 </style>


### PR DESCRIPTION
## Summary
- rebuild `src/pages/tjenester.astro` to use shared card grid and list utilities instead of repeated local section CSS
- structure the operating model content as a responsive `Split` with two reusable list blocks
- place the dark CTA inside a contained surface block to align with Stitch section treatment

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #36
- Parent epic: #29

## Dependency
- Stacked on #56 (`feature/29-shared-page-patterns`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refactors presentation/layout on `src/pages/tjenester.astro` to reuse shared utilities/components; low risk aside from potential visual/regression differences in responsive layout and spacing.
> 
> **Overview**
> Refactors `src/pages/tjenester.astro` to use shared layout patterns instead of page-specific CSS: the services list now uses the global `u-grid-cards u-grid-cards--2` utility, and the “Slik leverer vi” content is reorganized into a responsive two-column `Split` with `u-list-disc` lists.
> 
> Wraps the dark `ContactCTA` in a `FullBleed` container using the `surface-low` variant to align CTA section styling, and removes the now-redundant local grid/list styles (leaving only a small margin reset for `.u-list-disc`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb8246f623663c3bd1ad1451fba37ad44a32d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->