### PR TITLE
feat(projects): recompose projects page sections

### DIFF
--- a/src/pages/prosjekter/index.astro
+++ b/src/pages/prosjekter/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '@/layouts/Base.astro';
 import HeroSection from '@/components/HeroSection.astro';
+import NumberedConceptCard from '@/components/NumberedConceptCard.astro';
+import PageSection from '@/components/PageSection.astro';
 import { getProjectsWithDuration } from '@/utils/projectHelpers';
 import ProjectGrid from '@/components/projects/ProjectGrid.astro';
 import ContactCTA from '@/components/ContactCTA.astro';
@@ -22,6 +24,11 @@ const categories = [
     .map(([value, count]) => ({ label: value, value, count })),
 ];
 const categoryValues = categories.map((category) => category.value);
+const projectPrinciples = [
+  'Vi jobber i spenn mellom produkt, teknologi og organisasjon.',
+  'Vi prioriterer varig effekt over kortsiktig output.',
+  'Vi tar ansvar for gjennomføring sammen med teamet vi støtter.',
+];
 ---
 
 <Layout
@@ -34,8 +41,27 @@ const categoryValues = categories.map((category) => category.value);
     preamble="Et utvalg arbeid innen produktutvikling, teknologi, ledelse og forbedring i både nye og etablerte kontekster."
     tagline="Prosjekter"
   />
-  <CategoryFilter categories={categories} queryParam="kategori" />
-  <ProjectGrid projects={projects} />
+  <PageSection
+    heading="Prinsipper i praksis"
+    subheading="Prosjektene under viser hvordan vi kobler retning, tekniske valg og leveranse i samme løp."
+  >
+    <ul class="u-grid-cards u-grid-cards--3">
+      {
+        projectPrinciples.map((principle, index) => (
+          <li>
+            <NumberedConceptCard number={index + 1} title={principle} />
+          </li>
+        ))
+      }
+    </ul>
+  </PageSection>
+  <PageSection
+    heading="Utvalgte prosjekter"
+    subheading="Filtrer på fagområde for å se relevante caser."
+  >
+    <CategoryFilter categories={categories} queryParam="kategori" />
+    <ProjectGrid projects={projects} />
+  </PageSection>
   <script is:inline define:vars={{ categoryValues }}>
     (() => {
       const queryParam = 'kategori';


### PR DESCRIPTION
## Summary
- rebuild `src/pages/prosjekter/index.astro` to add a principles section and clearer page-level section hierarchy
- introduce `NumberedConceptCard` usage on projects for principles-first storytelling
- keep existing category filtering script and `ProjectGrid` behavior intact

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #37
- Parent epic: #29

## Dependency
- Stacked on #56 (`feature/29-shared-page-patterns`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentational changes to `src/pages/prosjekter/index.astro`; existing filtering script and project data fetching remain unchanged, so functional risk is minimal.
> 
> **Overview**
> Reworks the `Prosjekter` page layout into clearer sections by introducing `PageSection` wrappers and adding a new **"Prinsipper i praksis"** section.
> 
> The new principles section renders a small list of `projectPrinciples` using `NumberedConceptCard`, while the existing category filter + `ProjectGrid` are moved into an **"Utvalgte prosjekter"** section without altering the filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8cc08d5d9ecb665a5d602e9d1d0cf93e40a68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->