### PR TITLE
feat(careers): add dark full-bleed roles section

### DIFF
--- a/src/components/JobCard.astro
+++ b/src/components/JobCard.astro
@@ -9,12 +9,14 @@ type Props = {
   location?: string;
   employmentType?: string;
   tags?: string[];
+  tone?: 'default' | 'dark';
 };
 
-const { title, summary, href, location, employmentType, tags = [] } = Astro.props;
+const { title, summary, href, location, employmentType, tags = [], tone = 'default' } = Astro.props;
+const buttonVariant = tone === 'dark' ? 'tertiary' : 'primary';
 ---
 
-<article class="job-card">
+<article class:list={['job-card', tone === 'dark' && 'job-card--dark']}>
   <header>
     <h3>{title}</h3>
     <div class="meta">
@@ -37,7 +39,7 @@ const { title, summary, href, location, employmentType, tags = [] } = Astro.prop
     )
   }
 
-  <ButtonLink href={href} size="large">Les mer og søk</ButtonLink>
+  <ButtonLink href={href} size="large" variant={buttonVariant}>Les mer og søk</ButtonLink>
 </article>
 
 <style>
@@ -71,5 +73,16 @@ const { title, summary, href, location, employmentType, tags = [] } = Astro.prop
 
   .job-card p {
     font-size: var(--fs-body-m);
+  }
+
+  .job-card--dark {
+    border-color: var(--color-secondary);
+    background: color-mix(in srgb, var(--color-primary), white 8%);
+    color: var(--color-secondary);
+  }
+
+  .job-card--dark :global(.badge--outline) {
+    border-color: currentColor;
+    color: currentColor;
   }
 </style>

--- a/src/components/PageSection.astro
+++ b/src/components/PageSection.astro
@@ -42,6 +42,7 @@ const { id, heading, subheading } = Astro.props;
   h2 {
     font-size: var(--fs-heading-m);
     background-color: var(--color-accent);
+    color: var(--color-primary);
     padding: 0.5rem;
   }
 

--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -123,9 +123,9 @@ const processSteps = [
     <Split minBreakpoint="md" gap="2rem">
       <Prose wide slot="left">
         <p>
-          Vi bruker en trinnvis prosess for å bli kjent, diskutere forventninger og avklare praktiske
-          rammer. Hvis begge parter opplever god match, blir neste steg en invitasjon med tydelige
-          avtaler for arbeid og eierskap.
+          Vi bruker en trinnvis prosess for å bli kjent, diskutere forventninger og avklare
+          praktiske rammer. Hvis begge parter opplever god match, blir neste steg en invitasjon med
+          tydelige avtaler for arbeid og eierskap.
         </p>
       </Prose>
       <ul slot="right" class="u-list-disc">

--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -140,7 +140,7 @@ const processSteps = [
       subheading="Vi ansetter sjelden og bevisst. Når vi åpner roller, er det med tydelige forventninger."
     >
       <div class="u-grid-cards">
-        {openRoles.map((role) => <JobCard {...role} />)}
+        {openRoles.map((role) => <JobCard {...role} tone="dark" />)}
       </div>
     </PageSection>
   </FullBleed>
@@ -180,11 +180,5 @@ const processSteps = [
 <style>
   .u-list-disc {
     margin: 0;
-  }
-
-  :global(.fullBleed.dark .job-card) {
-    border-color: var(--color-secondary);
-    background: color-mix(in srgb, var(--color-primary), white 8%);
-    color: var(--color-secondary);
   }
 </style>

--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -4,6 +4,8 @@ import HeroSection from '@/components/HeroSection.astro';
 import JobCard from '@/components/JobCard.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
+import TeaserCard from '@/components/TeaserCard.astro';
+import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
 
 const principles = [
@@ -53,6 +55,12 @@ const openRoles = [
     tags: ['TypeScript', 'Astro', 'Produktfokus'],
   },
 ];
+
+const processSteps = [
+  'Først en kort forventningsavklaring om motivasjon, ansvar og retning.',
+  'Deretter en faglig samtale om valg, konsekvenser og samarbeid i praksis.',
+  'Til slutt en konkret invitasjon med tydelige rammer når begge parter ser match.',
+];
 ---
 
 <Layout
@@ -80,7 +88,7 @@ const openRoles = [
   </PageSection>
 
   <PageSection heading="Prinsipper" subheading="Disse prinsippene styrer hverdagen i Kynd.">
-    <ul class="list">
+    <ul class="u-list-disc">
       {principles.map((item) => <li>{item}</li>)}
     </ul>
   </PageSection>
@@ -102,7 +110,7 @@ const openRoles = [
     heading="Hvem vi ser etter"
     subheading="Vi er bevisst selektive. Riktig match er viktigere enn rask vekst."
   >
-    <ul class="list">
+    <ul class="u-list-disc">
       {weLookFor.map((item) => <li>{item}</li>)}
     </ul>
   </PageSection>
@@ -111,20 +119,25 @@ const openRoles = [
     heading="Dating og invitasjon"
     subheading="Rekrutteringsprosessen handler om gjensidig vurdering av verdi, tillit og samarbeid."
   >
-    <Prose wide>
-      <p>
-        Vi bruker en trinnvis prosess for å bli kjent, diskutere forventninger og avklare praktiske
-        rammer. Hvis begge parter opplever god match, blir neste steg en invitasjon med tydelige
-        avtaler for arbeid og eierskap.
-      </p>
-    </Prose>
+    <Split minBreakpoint="md" gap="2rem">
+      <Prose wide slot="left">
+        <p>
+          Vi bruker en trinnvis prosess for å bli kjent, diskutere forventninger og avklare praktiske
+          rammer. Hvis begge parter opplever god match, blir neste steg en invitasjon med tydelige
+          avtaler for arbeid og eierskap.
+        </p>
+      </Prose>
+      <ul slot="right" class="u-list-disc">
+        {processSteps.map((step) => <li>{step}</li>)}
+      </ul>
+    </Split>
   </PageSection>
 
   <PageSection
     heading="Aktuelle roller"
     subheading="Vi ansetter sjelden og bevisst. Når vi åpner roller, er det med tydelige forventninger."
   >
-    <div class="jobs-grid">
+    <div class="u-grid-cards">
       {openRoles.map((role) => <JobCard {...role} />)}
     </div>
   </PageSection>
@@ -133,16 +146,20 @@ const openRoles = [
     heading="Fordyp deg i håndboka"
     subheading="Vil du vite mer om hvordan vi jobber i praksis? Start med disse kapitlene."
   >
-    <div class="handbook-grid">
+    <ul class="u-grid-cards u-grid-cards--2">
       {
         handbookHighlights.map((chapter) => (
-          <article class="handbook-card">
-            <a href={chapter.href}>{chapter.title}</a>
-            <p>{chapter.description}</p>
-          </article>
+          <li>
+            <TeaserCard
+              title={chapter.title}
+              href={chapter.href}
+              description={chapter.description}
+              tone="secondary-shade"
+            />
+          </li>
         ))
       }
-    </div>
+    </ul>
     <Prose wide>
       <p>
         Hele håndboka er fortsatt offentlig tilgjengelig på <a href="/bok">/bok</a> for deg som vil gå
@@ -158,46 +175,7 @@ const openRoles = [
 </Layout>
 
 <style>
-  .list {
-    list-style: disc;
-    padding-inline-start: 1rem;
-    display: grid;
-    gap: 0.75rem;
-    font-size: var(--fs-body-m);
-  }
-
-  .handbook-grid {
-    display: grid;
-    gap: 1rem;
-
-    @media (--md) {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 1.5rem;
-    }
-  }
-
-  .jobs-grid {
-    display: grid;
-    gap: 1rem;
-  }
-
-  .handbook-card {
-    border: 2px solid var(--color-primary);
-    background: var(--color-secondary-shade);
-    padding: 1rem;
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  .handbook-card a {
-    font-size: var(--fs-heading-xs);
-    width: fit-content;
-    background-color: var(--color-accent);
-    padding: 0.2rem 0.4rem;
-  }
-
-  .handbook-card p {
-    font-size: var(--fs-body-s);
+  .u-list-disc {
     margin: 0;
   }
 </style>

--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -5,6 +5,7 @@ import JobCard from '@/components/JobCard.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import TeaserCard from '@/components/TeaserCard.astro';
+import FullBleed from '@/components/layout/FullBleed.astro';
 import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
 
@@ -133,14 +134,16 @@ const processSteps = [
     </Split>
   </PageSection>
 
-  <PageSection
-    heading="Aktuelle roller"
-    subheading="Vi ansetter sjelden og bevisst. Når vi åpner roller, er det med tydelige forventninger."
-  >
-    <div class="u-grid-cards">
-      {openRoles.map((role) => <JobCard {...role} />)}
-    </div>
-  </PageSection>
+  <FullBleed variant="dark">
+    <PageSection
+      heading="Aktuelle roller"
+      subheading="Vi ansetter sjelden og bevisst. Når vi åpner roller, er det med tydelige forventninger."
+    >
+      <div class="u-grid-cards">
+        {openRoles.map((role) => <JobCard {...role} />)}
+      </div>
+    </PageSection>
+  </FullBleed>
 
   <PageSection
     heading="Fordyp deg i håndboka"
@@ -177,5 +180,11 @@ const processSteps = [
 <style>
   .u-list-disc {
     margin: 0;
+  }
+
+  :global(.fullBleed.dark .job-card) {
+    border-color: var(--color-secondary);
+    background: color-mix(in srgb, var(--color-primary), white 8%);
+    color: var(--color-secondary);
   }
 </style>


### PR DESCRIPTION
## Summary
- update `src/pages/bli-en-av-oss.astro` to present open roles in a dark `FullBleed` block
- apply contextual job card styling to keep contrast/legibility inside the dark section
- preserve existing shared list/card structure from the careers rebuild baseline

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #38
- Parent epic: #29

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily presentational/layout changes with a small, opt-in `JobCard` styling prop; low risk aside from potential visual regressions across pages that use `JobCard`.
> 
> **Overview**
> Updates `bli-en-av-oss.astro` to wrap the “Aktuelle roller” section in a dark `FullBleed` block, switch to shared utility grid/list classes, and use `TeaserCard` for handbook highlight cards.
> 
> Enhances `JobCard.astro` with an optional `tone="dark"` mode that adjusts card colors and outline badge styling, and swaps the CTA button variant to maintain legibility on dark backgrounds. The recruiting “Dating og invitasjon” section is also restructured into a `Split` layout with an explicit step list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9aa3d6f2bd5cf7ad00b9f767deead9f4e65d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->