### PR TITLE
feat(about): finalize CTA treatment

### DIFF
--- a/src/components/PageSection.astro
+++ b/src/components/PageSection.astro
@@ -42,6 +42,7 @@ const { id, heading, subheading } = Astro.props;
   h2 {
     font-size: var(--fs-heading-m);
     background-color: var(--color-accent);
+    color: var(--color-primary);
     padding: 0.5rem;
   }
 

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -10,7 +10,7 @@ const leftMargin = align === 'left' ? '0' : 'auto';
 const rightMargin = align === 'right' ? '0' : 'auto';
 ---
 
-<div data-wide={wide}>
+<div class="prose" data-wide={wide}>
   <slot />
 </div>
 

--- a/src/pages/om-kynd.astro
+++ b/src/pages/om-kynd.astro
@@ -104,7 +104,9 @@ const coreValues = [
     />
   </PageSection>
 
-  <ContactCTA />
+  <FullBleed variant="surface-low">
+    <ContactCTA variant="surface-low" />
+  </FullBleed>
 </Layout>
 
 <style>

--- a/src/pages/om-kynd.astro
+++ b/src/pages/om-kynd.astro
@@ -1,10 +1,19 @@
 ---
 import ContactCTA from '@/components/ContactCTA.astro';
 import HeroSection from '@/components/HeroSection.astro';
+import NumberedConceptCard from '@/components/NumberedConceptCard.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import QuoteBlock from '@/components/QuoteBlock.astro';
+import TeaserCard from '@/components/TeaserCard.astro';
+import FullBleed from '@/components/layout/FullBleed.astro';
 import Layout from '@/layouts/Base.astro';
+
+const coreValues = [
+  'Integritet i tekniske og strategiske anbefalinger.',
+  'Tydelig kommunikasjon fremfor konsulentspråk.',
+  'Ansvar for effekt, ikke bare aktivitet.',
+];
 ---
 
 <Layout
@@ -44,7 +53,7 @@ import Layout from '@/layouts/Base.astro';
       author="Kynd"
       authorRole="Arbeidsform"
     />
-    <ul class="difference-list">
+    <ul class="u-list-disc">
       <li>Senior kompetanse tett på beslutninger med høy konsekvens.</li>
       <li>Selektivt samarbeid med tydelige forventninger til begge parter.</li>
       <li>Konkret rådgivning og operativ levering i samme team.</li>
@@ -53,44 +62,57 @@ import Layout from '@/layouts/Base.astro';
   </PageSection>
 
   <PageSection
-    heading="Konsulentarbeid og produktambisjon"
-    subheading="Vi bygger verdi for kunder i dag, og bygger også kompetanse og produkter på lang sikt."
+    heading="Verdier i praksis"
+    subheading="Disse verdiene styrer hvordan vi prioriterer i usikre og komplekse produktløp."
   >
-    <Prose wide>
-      <p>
-        Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
-        konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene til
-        å utvikle egne initiativer over tid.
-      </p>
-      <p>
-        Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å
-        virke annerledes, men å være nyttige i krevende kontekster.
-      </p>
-    </Prose>
+    <ul class="u-grid-cards u-grid-cards--3">
+      {
+        coreValues.map((value, index) => (
+          <li>
+            <NumberedConceptCard number={index + 1} title={value} />
+          </li>
+        ))
+      }
+    </ul>
   </PageSection>
 
+  <FullBleed variant="dark">
+    <PageSection
+      heading="Konsulentarbeid og produktambisjon"
+      subheading="Vi bygger verdi for kunder i dag, og bygger også kompetanse og produkter på lang sikt."
+    >
+      <Prose wide>
+        <p>
+          Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
+          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene
+          til å utvikle egne initiativer over tid.
+        </p>
+        <p>
+          Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å
+          virke annerledes, men å være nyttige i krevende kontekster.
+        </p>
+      </Prose>
+    </PageSection>
+  </FullBleed>
+
   <PageSection heading="Folka i Kynd" subheading="Menneskene bak leveransene.">
-    <a class="people-link" href="/folka">Møt folka</a>
+    <TeaserCard
+      title="Møt folka"
+      href="/folka"
+      description="Bli kjent med menneskene som bygger Kynd i praksis."
+      tone="secondary"
+    />
   </PageSection>
 
   <ContactCTA />
 </Layout>
 
 <style>
-  .difference-list {
-    list-style: disc;
-    padding-inline-start: 1rem;
-    display: grid;
-    gap: 0.75rem;
-    font-size: var(--fs-body-m);
+  .u-list-disc {
+    margin: 0;
   }
 
-  .people-link {
-    display: inline-block;
-    font-size: var(--fs-heading-xs);
-    background-color: var(--color-accent);
-    color: var(--color-primary);
-    padding: 0.5rem 0.75rem;
-    border: 2px solid var(--color-primary);
+  :global(.fullBleed.dark .prose) {
+    color: var(--color-secondary);
   }
 </style>


### PR DESCRIPTION
## Summary
- finalize `src/pages/om-kynd.astro` by wrapping the closing CTA in a contained surface block
- align page closing rhythm with the rest of the page-section architecture

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`

## Issue linkage
- Advances #39
- Parent epic: #29

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly content/layout and styling tweaks on the About page; low risk aside from potential visual regressions from new `FullBleed` wrappers and updated CSS hooks.
> 
> **Overview**
> Refines the `om-kynd` about page layout by introducing a new "Verdier i praksis" section rendered from a `coreValues` list using `NumberedConceptCard`, and moving the existing "Konsulentarbeid og produktambisjon" copy into a dark `FullBleed` block.
> 
> Updates the page close to match the new section rhythm by replacing the plain "Møt folka" link with a `TeaserCard` and wrapping the final `ContactCTA` in a `FullBleed` `surface-low` container with a matching `variant` prop.
> 
> Includes small styling adjustments: `PageSection` headings now explicitly set text color, `Prose` gains a `.prose` class to enable targeted theming (used for the dark full-bleed section), and list styling is simplified to a utility class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f42536f336ea0756ab65793f39706d20d78150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->