### PR TITLE
Add issue hygiene guardrails

### DIFF
--- a/.cursor/rules/github-issue-hygiene.mdc
+++ b/.cursor/rules/github-issue-hygiene.mdc
@@ -1,0 +1,16 @@
+---
+description: Keep GitHub issues aligned with delivered work
+alwaysApply: true
+---
+
+# GitHub Issue Hygiene
+
+- Treat issue maintenance as part of done when a task involves GitHub issues, PRs, or merged work.
+- If issue scope is unclear, ask which issue numbers are in scope before wrapping up.
+- Distinguish between issue `state`, labels, and GitHub Project `Status`; if the user says "status" ambiguously, clarify which one they mean.
+- When work is complete and merged, review linked issues and update them instead of only mentioning them in chat.
+- Close issues whose scope is delivered; if the work is partial, keep the issue open and add a short comment describing what remains.
+- When work lands on `overhaul`, do not wait for `main` before closing an issue whose scope is delivered.
+- Remove stale `blocked` labels or equivalent blockers when the dependency is resolved.
+- When closing an issue after a merged PR, add a short comment linking the relevant PR(s) and noting whether the merge target was `overhaul` or `main`.
+- If tooling, permissions, or missing issue references prevent an update, say so explicitly in the final response instead of silently skipping issue hygiene.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,11 @@
 ## Linked Issues
 
 <!-- Use closing keywords only for issues fully delivered by this PR. -->
+
 - Closes #
 
 <!-- Use related references for issues that should stay open after merge. -->
+
 - Related:
 
 ## Issue Hygiene

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What changed, and why? Keep this focused on intent. -->
+
+## Linked Issues
+
+<!-- Use closing keywords only for issues fully delivered by this PR. -->
+- Closes #
+
+<!-- Use related references for issues that should stay open after merge. -->
+- Related:
+
+## Issue Hygiene
+
+- [ ] Any fully delivered issue is linked with a closing keyword.
+- [ ] Any partially addressed issue is called out with remaining scope.
+- [ ] Issue labels, blockers, and project status were updated, or are not applicable.
+
+## Testing
+
+- [ ] `pnpm check`
+- [ ] Manual verification completed

--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -1,0 +1,426 @@
+import { readFile } from "node:fs/promises";
+
+// Optional repository variables:
+// - ISSUE_HYGIENE_BASE_BRANCHES=main,overhaul
+// - ISSUE_HYGIENE_BLOCKED_LABELS=blocked,blocked-by-dependency
+// - ISSUE_HYGIENE_PROJECT_OWNER=kynd
+// - ISSUE_HYGIENE_PROJECT_NUMBER=1
+// - ISSUE_HYGIENE_STATUS_FIELD_NAME=Status
+// - ISSUE_HYGIENE_DONE_OPTION_NAME=Done
+
+const REST_API_BASE = process.env.GITHUB_API_URL || "https://api.github.com";
+const GRAPHQL_API_URL =
+  process.env.GITHUB_GRAPHQL_URL || "https://api.github.com/graphql";
+const CLOSING_KEYWORD_PATTERN =
+  /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b/i;
+
+function log(message) {
+  console.log(`[issue-hygiene] ${message}`);
+}
+
+function fail(message) {
+  console.error(`[issue-hygiene] ${message}`);
+}
+
+function parseCsv(value, fallback = []) {
+  if (!value || !value.trim()) {
+    return fallback;
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseClosingIssueNumbers(text, owner, repo) {
+  const refs = new Set();
+  const fullRepoRefPattern = new RegExp(
+    `${escapeRegExp(owner)}\\/${escapeRegExp(repo)}#(\\d+)`,
+    "gi",
+  );
+  const shortRefPattern = /(^|[^\w/])#(\d+)/g;
+  const issueUrlPattern = new RegExp(
+    `https?:\\/\\/github\\.com\\/${escapeRegExp(owner)}\\/${escapeRegExp(repo)}\\/issues\\/(\\d+)`,
+    "gi",
+  );
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!CLOSING_KEYWORD_PATTERN.test(line)) {
+      continue;
+    }
+
+    for (const match of line.matchAll(fullRepoRefPattern)) {
+      refs.add(Number(match[1]));
+    }
+
+    for (const match of line.matchAll(issueUrlPattern)) {
+      refs.add(Number(match[1]));
+    }
+
+    for (const match of line.matchAll(shortRefPattern)) {
+      refs.add(Number(match[2]));
+    }
+  }
+
+  return [...refs];
+}
+
+async function githubRequest(path, init = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("Missing GITHUB_TOKEN.");
+  }
+
+  const response = await fetch(`${REST_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "kynd-web-issue-hygiene",
+      ...(init.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub REST ${response.status} for ${path}: ${body}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+async function graphqlRequest(query, variables) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("Missing GITHUB_TOKEN.");
+  }
+
+  const response = await fetch(GRAPHQL_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "kynd-web-issue-hygiene",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok || payload.errors?.length) {
+    throw new Error(
+      `GitHub GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`,
+    );
+  }
+
+  return payload.data;
+}
+
+async function updateProjectStatus(issueNodeId, config) {
+  if (!config.projectNumber) {
+    return null;
+  }
+
+  const projectQuery = `
+    query IssueProjectLookup($login: String!, $projectNumber: Int!, $issueId: ID!) {
+      organization(login: $login) {
+        projectV2(number: $projectNumber) {
+          id
+          title
+          fields(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2FieldCommon {
+                id
+                name
+              }
+              ... on ProjectV2SingleSelectField {
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+      user(login: $login) {
+        projectV2(number: $projectNumber) {
+          id
+          title
+          fields(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2FieldCommon {
+                id
+                name
+              }
+              ... on ProjectV2SingleSelectField {
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+      node(id: $issueId) {
+        ... on Issue {
+          projectItems(first: 100) {
+            nodes {
+              id
+              project {
+                ... on ProjectV2 {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const projectData = await graphqlRequest(projectQuery, {
+    login: config.projectOwner,
+    projectNumber: config.projectNumber,
+    issueId: issueNodeId,
+  });
+
+  const project =
+    projectData.organization?.projectV2 || projectData.user?.projectV2 || null;
+
+  if (!project) {
+    log(
+      `Project ${config.projectOwner} #${config.projectNumber} was not found; skipping project sync.`,
+    );
+    return null;
+  }
+
+  const statusField = project.fields.nodes.find(
+    (field) =>
+      field?.name === config.statusFieldName &&
+      field.__typename === "ProjectV2SingleSelectField",
+  );
+
+  if (!statusField) {
+    log(
+      `Project field "${config.statusFieldName}" was not found on project ${config.projectNumber}; skipping project sync.`,
+    );
+    return null;
+  }
+
+  const doneOption = statusField.options.find(
+    (option) => option.name === config.doneOptionName,
+  );
+
+  if (!doneOption) {
+    log(
+      `Project option "${config.doneOptionName}" was not found on field "${config.statusFieldName}"; skipping project sync.`,
+    );
+    return null;
+  }
+
+  const projectItem = projectData.node?.projectItems?.nodes.find(
+    (item) => item.project?.id === project.id,
+  );
+
+  if (!projectItem) {
+    log(
+      `Issue is not on project ${config.projectNumber}; skipping project sync.`,
+    );
+    return null;
+  }
+
+  const mutation = `
+    mutation UpdateProjectStatus(
+      $projectId: ID!
+      $itemId: ID!
+      $fieldId: ID!
+      $optionId: String!
+    ) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `;
+
+  await graphqlRequest(mutation, {
+    projectId: project.id,
+    itemId: projectItem.id,
+    fieldId: statusField.id,
+    optionId: doneOption.id,
+  });
+
+  return `Updated project status to \`${config.doneOptionName}\``;
+}
+
+async function closeIssue(owner, repo, issueNumber) {
+  return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      state: "closed",
+      state_reason: "completed",
+    }),
+  });
+}
+
+async function deleteLabel(owner, repo, issueNumber, labelName) {
+  return githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`,
+    { method: "DELETE" },
+  );
+}
+
+async function addComment(owner, repo, issueNumber, body) {
+  return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+}
+
+async function processIssue(owner, repo, issueNumber, pullRequest, config) {
+  const issue = await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`);
+
+  if (issue.pull_request) {
+    log(`#${issueNumber} is a pull request, not an issue; skipping.`);
+    return;
+  }
+
+  const actions = [];
+
+  if (issue.state !== "closed") {
+    await closeIssue(owner, repo, issueNumber);
+    actions.push("Closed as completed");
+  }
+
+  const labels = (issue.labels || []).map((label) => label.name).filter(Boolean);
+  const blockedLabels = labels.filter((label) =>
+    config.blockedLabels.has(label.toLowerCase()),
+  );
+
+  for (const label of blockedLabels) {
+    await deleteLabel(owner, repo, issueNumber, label);
+  }
+
+  if (blockedLabels.length > 0) {
+    actions.push(
+      `Removed blocker label${blockedLabels.length > 1 ? "s" : ""}: ${blockedLabels
+        .map((label) => `\`${label}\``)
+        .join(", ")}`,
+    );
+  }
+
+  const projectAction = await updateProjectStatus(issue.node_id, config);
+  if (projectAction) {
+    actions.push(projectAction);
+  }
+
+  if (actions.length === 0) {
+    log(`#${issueNumber} did not need any updates.`);
+    return;
+  }
+
+  await addComment(
+    owner,
+    repo,
+    issueNumber,
+    [
+      `Updated automatically after PR #${pullRequest.number} merged into \`${pullRequest.base.ref}\`.`,
+      "",
+      ...actions.map((action) => `- ${action}`),
+      "",
+      pullRequest.html_url,
+    ].join("\n"),
+  );
+
+  log(`#${issueNumber}: ${actions.join("; ")}.`);
+}
+
+async function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    throw new Error("Missing GITHUB_EVENT_PATH.");
+  }
+
+  const event = JSON.parse(await readFile(eventPath, "utf8"));
+  const pullRequest = event.pull_request;
+
+  if (!pullRequest?.merged) {
+    log("Pull request was not merged; nothing to do.");
+    return;
+  }
+
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || "").split("/");
+  if (!owner || !repo) {
+    throw new Error("Missing GITHUB_REPOSITORY.");
+  }
+
+  const allowedBaseBranches = new Set(
+    parseCsv(process.env.ISSUE_HYGIENE_BASE_BRANCHES, ["main", "overhaul"]),
+  );
+
+  if (!allowedBaseBranches.has(pullRequest.base.ref)) {
+    log(
+      `Base branch "${pullRequest.base.ref}" is not configured for issue hygiene; skipping.`,
+    );
+    return;
+  }
+
+  const linkedIssueNumbers = parseClosingIssueNumbers(
+    `${pullRequest.title || ""}\n${pullRequest.body || ""}`,
+    owner,
+    repo,
+  );
+
+  if (linkedIssueNumbers.length === 0) {
+    log("No closing issue references found in the merged PR.");
+    return;
+  }
+
+  const config = {
+    blockedLabels: new Set(
+      parseCsv(process.env.ISSUE_HYGIENE_BLOCKED_LABELS, ["blocked"]).map((label) =>
+        label.toLowerCase(),
+      ),
+    ),
+    doneOptionName: process.env.ISSUE_HYGIENE_DONE_OPTION_NAME?.trim() || "Done",
+    projectNumber: Number.parseInt(
+      process.env.ISSUE_HYGIENE_PROJECT_NUMBER || "",
+      10,
+    ),
+    projectOwner:
+      process.env.ISSUE_HYGIENE_PROJECT_OWNER?.trim() || owner,
+    statusFieldName:
+      process.env.ISSUE_HYGIENE_STATUS_FIELD_NAME?.trim() || "Status",
+  };
+
+  for (const issueNumber of linkedIssueNumbers) {
+    await processIssue(owner, repo, issueNumber, pullRequest, config);
+  }
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -11,8 +11,6 @@ import { pathToFileURL } from 'node:url';
 
 const REST_API_BASE = process.env.GITHUB_API_URL || 'https://api.github.com';
 const GRAPHQL_API_URL = process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
-const CLOSING_KEYWORD_PATTERN =
-  /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b/i;
 
 function log(message) {
   console.log(`[issue-hygiene] ${message}`);
@@ -37,33 +35,55 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function createIssueReferenceConfig(owner, repo) {
+  const fullRepoRefSource = `${escapeRegExp(owner)}\\/${escapeRegExp(repo)}#\\d+`;
+  const issueUrlSource = `https?:\\/\\/github\\.com\\/${escapeRegExp(owner)}\\/${escapeRegExp(
+    repo,
+  )}\\/issues\\/\\d+`;
+  const shortRefSource = '#\\d+';
+  const issueReferenceSource = `(?:${fullRepoRefSource}|${issueUrlSource}|${shortRefSource})`;
+
+  return {
+    issueReferenceSource,
+    extractIssueNumber(reference) {
+      const fullRepoRefMatch = reference.match(new RegExp(`^${fullRepoRefSource}$`, 'i'));
+      if (fullRepoRefMatch) {
+        return Number(fullRepoRefMatch[0].split('#')[1]);
+      }
+
+      const issueUrlMatch = reference.match(new RegExp(`^${issueUrlSource}$`, 'i'));
+      if (issueUrlMatch) {
+        return Number(issueUrlMatch[0].split('/').at(-1));
+      }
+
+      const shortRefMatch = reference.match(/^#(\d+)$/);
+      if (shortRefMatch) {
+        return Number(shortRefMatch[1]);
+      }
+
+      return null;
+    },
+  };
+}
+
 export function parseClosingIssueNumbers(text, owner, repo) {
   const refs = new Set();
-  const fullRepoRefPattern = new RegExp(
-    `${escapeRegExp(owner)}\\/${escapeRegExp(repo)}#(\\d+)`,
-    'gi',
-  );
-  const shortRefPattern = /(^|[^\w/])#(\d+)/g;
-  const issueUrlPattern = new RegExp(
-    `https?:\\/\\/github\\.com\\/${escapeRegExp(owner)}\\/${escapeRegExp(repo)}\\/issues\\/(\\d+)`,
+  const { issueReferenceSource, extractIssueNumber } = createIssueReferenceConfig(owner, repo);
+  const closingClausePattern = new RegExp(
+    String.raw`\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b\s*:?\s*(?:issues?\s+)?((?:${issueReferenceSource})(?:\s*(?:,\s*|(?:and|or)\s+)(?:${issueReferenceSource}))*)`,
     'gi',
   );
 
   for (const line of text.split(/\r?\n/)) {
-    if (!CLOSING_KEYWORD_PATTERN.test(line)) {
-      continue;
-    }
+    for (const clauseMatch of line.matchAll(closingClausePattern)) {
+      const references = clauseMatch[1].match(new RegExp(issueReferenceSource, 'gi')) || [];
 
-    for (const match of line.matchAll(fullRepoRefPattern)) {
-      refs.add(Number(match[1]));
-    }
-
-    for (const match of line.matchAll(issueUrlPattern)) {
-      refs.add(Number(match[1]));
-    }
-
-    for (const match of line.matchAll(shortRefPattern)) {
-      refs.add(Number(match[2]));
+      for (const reference of references) {
+        const issueNumber = extractIssueNumber(reference);
+        if (issueNumber !== null) {
+          refs.add(issueNumber);
+        }
+      }
     }
   }
 

--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
 
 // Optional repository variables:
 // - ISSUE_HYGIENE_BASE_BRANCHES=main,overhaul
@@ -36,7 +37,7 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function parseClosingIssueNumbers(text, owner, repo) {
+export function parseClosingIssueNumbers(text, owner, repo) {
   const refs = new Set();
   const fullRepoRefPattern = new RegExp(
     `${escapeRegExp(owner)}\\/${escapeRegExp(repo)}#(\\d+)`,
@@ -346,7 +347,36 @@ async function processIssue(owner, repo, issueNumber, pullRequest, config) {
   log(`#${issueNumber}: ${actions.join('; ')}.`);
 }
 
-async function main() {
+export async function processLinkedIssues(
+  owner,
+  repo,
+  linkedIssueNumbers,
+  pullRequest,
+  config,
+  processIssueFn = processIssue,
+) {
+  const failedIssueNumbers = [];
+
+  for (const issueNumber of linkedIssueNumbers) {
+    try {
+      await processIssueFn(owner, repo, issueNumber, pullRequest, config);
+    } catch (error) {
+      const message = error instanceof Error ? error.stack || error.message : String(error);
+      fail(`Failed to process issue #${issueNumber}: ${message}`);
+      failedIssueNumbers.push(issueNumber);
+    }
+  }
+
+  if (failedIssueNumbers.length > 0) {
+    throw new Error(
+      `Issue hygiene failed for ${failedIssueNumbers.length} issue(s): ${failedIssueNumbers
+        .map((issueNumber) => `#${issueNumber}`)
+        .join(', ')}`,
+    );
+  }
+}
+
+export async function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
     throw new Error('Missing GITHUB_EVENT_PATH.');
@@ -397,12 +427,14 @@ async function main() {
     statusFieldName: process.env.ISSUE_HYGIENE_STATUS_FIELD_NAME?.trim() || 'Status',
   };
 
-  for (const issueNumber of linkedIssueNumbers) {
-    await processIssue(owner, repo, issueNumber, pullRequest, config);
-  }
+  await processLinkedIssues(owner, repo, linkedIssueNumbers, pullRequest, config);
 }
 
-main().catch((error) => {
-  fail(error instanceof Error ? error.stack || error.message : String(error));
-  process.exitCode = 1;
-});
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main().catch((error) => {
+    fail(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile } from 'node:fs/promises';
 
 // Optional repository variables:
 // - ISSUE_HYGIENE_BASE_BRANCHES=main,overhaul
@@ -8,9 +8,8 @@ import { readFile } from "node:fs/promises";
 // - ISSUE_HYGIENE_STATUS_FIELD_NAME=Status
 // - ISSUE_HYGIENE_DONE_OPTION_NAME=Done
 
-const REST_API_BASE = process.env.GITHUB_API_URL || "https://api.github.com";
-const GRAPHQL_API_URL =
-  process.env.GITHUB_GRAPHQL_URL || "https://api.github.com/graphql";
+const REST_API_BASE = process.env.GITHUB_API_URL || 'https://api.github.com';
+const GRAPHQL_API_URL = process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
 const CLOSING_KEYWORD_PATTERN =
   /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b/i;
 
@@ -28,25 +27,25 @@ function parseCsv(value, fallback = []) {
   }
 
   return value
-    .split(",")
+    .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean);
 }
 
 function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function parseClosingIssueNumbers(text, owner, repo) {
   const refs = new Set();
   const fullRepoRefPattern = new RegExp(
     `${escapeRegExp(owner)}\\/${escapeRegExp(repo)}#(\\d+)`,
-    "gi",
+    'gi',
   );
   const shortRefPattern = /(^|[^\w/])#(\d+)/g;
   const issueUrlPattern = new RegExp(
     `https?:\\/\\/github\\.com\\/${escapeRegExp(owner)}\\/${escapeRegExp(repo)}\\/issues\\/(\\d+)`,
-    "gi",
+    'gi',
   );
 
   for (const line of text.split(/\r?\n/)) {
@@ -73,16 +72,16 @@ function parseClosingIssueNumbers(text, owner, repo) {
 async function githubRequest(path, init = {}) {
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
-    throw new Error("Missing GITHUB_TOKEN.");
+    throw new Error('Missing GITHUB_TOKEN.');
   }
 
   const response = await fetch(`${REST_API_BASE}${path}`, {
     ...init,
     headers: {
-      Accept: "application/vnd.github+json",
+      Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "kynd-web-issue-hygiene",
+      'Content-Type': 'application/json',
+      'User-Agent': 'kynd-web-issue-hygiene',
       ...(init.headers || {}),
     },
   });
@@ -102,15 +101,15 @@ async function githubRequest(path, init = {}) {
 async function graphqlRequest(query, variables) {
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
-    throw new Error("Missing GITHUB_TOKEN.");
+    throw new Error('Missing GITHUB_TOKEN.');
   }
 
   const response = await fetch(GRAPHQL_API_URL, {
-    method: "POST",
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "kynd-web-issue-hygiene",
+      'Content-Type': 'application/json',
+      'User-Agent': 'kynd-web-issue-hygiene',
     },
     body: JSON.stringify({ query, variables }),
   });
@@ -118,9 +117,7 @@ async function graphqlRequest(query, variables) {
   const payload = await response.json();
 
   if (!response.ok || payload.errors?.length) {
-    throw new Error(
-      `GitHub GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`,
-    );
+    throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`);
   }
 
   return payload.data;
@@ -198,8 +195,7 @@ async function updateProjectStatus(issueNodeId, config) {
     issueId: issueNodeId,
   });
 
-  const project =
-    projectData.organization?.projectV2 || projectData.user?.projectV2 || null;
+  const project = projectData.organization?.projectV2 || projectData.user?.projectV2 || null;
 
   if (!project) {
     log(
@@ -210,8 +206,7 @@ async function updateProjectStatus(issueNodeId, config) {
 
   const statusField = project.fields.nodes.find(
     (field) =>
-      field?.name === config.statusFieldName &&
-      field.__typename === "ProjectV2SingleSelectField",
+      field?.name === config.statusFieldName && field.__typename === 'ProjectV2SingleSelectField',
   );
 
   if (!statusField) {
@@ -221,9 +216,7 @@ async function updateProjectStatus(issueNodeId, config) {
     return null;
   }
 
-  const doneOption = statusField.options.find(
-    (option) => option.name === config.doneOptionName,
-  );
+  const doneOption = statusField.options.find((option) => option.name === config.doneOptionName);
 
   if (!doneOption) {
     log(
@@ -237,9 +230,7 @@ async function updateProjectStatus(issueNodeId, config) {
   );
 
   if (!projectItem) {
-    log(
-      `Issue is not on project ${config.projectNumber}; skipping project sync.`,
-    );
+    log(`Issue is not on project ${config.projectNumber}; skipping project sync.`);
     return null;
   }
 
@@ -277,10 +268,10 @@ async function updateProjectStatus(issueNodeId, config) {
 
 async function closeIssue(owner, repo, issueNumber) {
   return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
-    method: "PATCH",
+    method: 'PATCH',
     body: JSON.stringify({
-      state: "closed",
-      state_reason: "completed",
+      state: 'closed',
+      state_reason: 'completed',
     }),
   });
 }
@@ -288,13 +279,13 @@ async function closeIssue(owner, repo, issueNumber) {
 async function deleteLabel(owner, repo, issueNumber, labelName) {
   return githubRequest(
     `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`,
-    { method: "DELETE" },
+    { method: 'DELETE' },
   );
 }
 
 async function addComment(owner, repo, issueNumber, body) {
   return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
-    method: "POST",
+    method: 'POST',
     body: JSON.stringify({ body }),
   });
 }
@@ -309,15 +300,13 @@ async function processIssue(owner, repo, issueNumber, pullRequest, config) {
 
   const actions = [];
 
-  if (issue.state !== "closed") {
+  if (issue.state !== 'closed') {
     await closeIssue(owner, repo, issueNumber);
-    actions.push("Closed as completed");
+    actions.push('Closed as completed');
   }
 
   const labels = (issue.labels || []).map((label) => label.name).filter(Boolean);
-  const blockedLabels = labels.filter((label) =>
-    config.blockedLabels.has(label.toLowerCase()),
-  );
+  const blockedLabels = labels.filter((label) => config.blockedLabels.has(label.toLowerCase()));
 
   for (const label of blockedLabels) {
     await deleteLabel(owner, repo, issueNumber, label);
@@ -325,9 +314,9 @@ async function processIssue(owner, repo, issueNumber, pullRequest, config) {
 
   if (blockedLabels.length > 0) {
     actions.push(
-      `Removed blocker label${blockedLabels.length > 1 ? "s" : ""}: ${blockedLabels
+      `Removed blocker label${blockedLabels.length > 1 ? 's' : ''}: ${blockedLabels
         .map((label) => `\`${label}\``)
-        .join(", ")}`,
+        .join(', ')}`,
     );
   }
 
@@ -347,72 +336,65 @@ async function processIssue(owner, repo, issueNumber, pullRequest, config) {
     issueNumber,
     [
       `Updated automatically after PR #${pullRequest.number} merged into \`${pullRequest.base.ref}\`.`,
-      "",
+      '',
       ...actions.map((action) => `- ${action}`),
-      "",
+      '',
       pullRequest.html_url,
-    ].join("\n"),
+    ].join('\n'),
   );
 
-  log(`#${issueNumber}: ${actions.join("; ")}.`);
+  log(`#${issueNumber}: ${actions.join('; ')}.`);
 }
 
 async function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
-    throw new Error("Missing GITHUB_EVENT_PATH.");
+    throw new Error('Missing GITHUB_EVENT_PATH.');
   }
 
-  const event = JSON.parse(await readFile(eventPath, "utf8"));
+  const event = JSON.parse(await readFile(eventPath, 'utf8'));
   const pullRequest = event.pull_request;
 
   if (!pullRequest?.merged) {
-    log("Pull request was not merged; nothing to do.");
+    log('Pull request was not merged; nothing to do.');
     return;
   }
 
-  const [owner, repo] = (process.env.GITHUB_REPOSITORY || "").split("/");
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || '').split('/');
   if (!owner || !repo) {
-    throw new Error("Missing GITHUB_REPOSITORY.");
+    throw new Error('Missing GITHUB_REPOSITORY.');
   }
 
   const allowedBaseBranches = new Set(
-    parseCsv(process.env.ISSUE_HYGIENE_BASE_BRANCHES, ["main", "overhaul"]),
+    parseCsv(process.env.ISSUE_HYGIENE_BASE_BRANCHES, ['main', 'overhaul']),
   );
 
   if (!allowedBaseBranches.has(pullRequest.base.ref)) {
-    log(
-      `Base branch "${pullRequest.base.ref}" is not configured for issue hygiene; skipping.`,
-    );
+    log(`Base branch "${pullRequest.base.ref}" is not configured for issue hygiene; skipping.`);
     return;
   }
 
   const linkedIssueNumbers = parseClosingIssueNumbers(
-    `${pullRequest.title || ""}\n${pullRequest.body || ""}`,
+    `${pullRequest.title || ''}\n${pullRequest.body || ''}`,
     owner,
     repo,
   );
 
   if (linkedIssueNumbers.length === 0) {
-    log("No closing issue references found in the merged PR.");
+    log('No closing issue references found in the merged PR.');
     return;
   }
 
   const config = {
     blockedLabels: new Set(
-      parseCsv(process.env.ISSUE_HYGIENE_BLOCKED_LABELS, ["blocked"]).map((label) =>
+      parseCsv(process.env.ISSUE_HYGIENE_BLOCKED_LABELS, ['blocked']).map((label) =>
         label.toLowerCase(),
       ),
     ),
-    doneOptionName: process.env.ISSUE_HYGIENE_DONE_OPTION_NAME?.trim() || "Done",
-    projectNumber: Number.parseInt(
-      process.env.ISSUE_HYGIENE_PROJECT_NUMBER || "",
-      10,
-    ),
-    projectOwner:
-      process.env.ISSUE_HYGIENE_PROJECT_OWNER?.trim() || owner,
-    statusFieldName:
-      process.env.ISSUE_HYGIENE_STATUS_FIELD_NAME?.trim() || "Status",
+    doneOptionName: process.env.ISSUE_HYGIENE_DONE_OPTION_NAME?.trim() || 'Done',
+    projectNumber: Number.parseInt(process.env.ISSUE_HYGIENE_PROJECT_NUMBER || '', 10),
+    projectOwner: process.env.ISSUE_HYGIENE_PROJECT_OWNER?.trim() || owner,
+    statusFieldName: process.env.ISSUE_HYGIENE_STATUS_FIELD_NAME?.trim() || 'Status',
   };
 
   for (const issueNumber of linkedIssueNumbers) {

--- a/.github/scripts/issue-hygiene-on-merge.test.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { processLinkedIssues } from './issue-hygiene-on-merge.mjs';
+import { parseClosingIssueNumbers, processLinkedIssues } from './issue-hygiene-on-merge.mjs';
 
 test('processLinkedIssues continues after a per-issue failure and reports all failed issue numbers', async () => {
   const attemptedIssues = [];
@@ -33,4 +33,19 @@ test('processLinkedIssues continues after a per-issue failure and reports all fa
   );
 
   assert.deepEqual(attemptedIssues, [10, 20, 30, 40]);
+});
+
+test('parseClosingIssueNumbers only closes references directly attached to a closing keyword', () => {
+  const closingIssueNumbers = parseClosingIssueNumbers(
+    [
+      'Resolves #10, see #20 for context.',
+      'Fixed the bug reported in #30.',
+      'Closes #40 and kynd-no/kynd-web#41.',
+      'Fixes https://github.com/kynd-no/kynd-web/issues/42.',
+    ].join('\n'),
+    'kynd-no',
+    'kynd-web',
+  );
+
+  assert.deepEqual(closingIssueNumbers, [10, 40, 41, 42]);
 });

--- a/.github/scripts/issue-hygiene-on-merge.test.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { processLinkedIssues } from './issue-hygiene-on-merge.mjs';
+
+test('processLinkedIssues continues after a per-issue failure and reports all failed issue numbers', async () => {
+  const attemptedIssues = [];
+  const pullRequest = {
+    base: { ref: 'overhaul' },
+    html_url: 'https://github.com/kynd-no/kynd-web/pull/123',
+    number: 123,
+  };
+
+  const processIssueStub = async (_owner, _repo, issueNumber) => {
+    attemptedIssues.push(issueNumber);
+
+    if (issueNumber === 20 || issueNumber === 40) {
+      throw new Error(`simulated failure for #${issueNumber}`);
+    }
+  };
+
+  await assert.rejects(
+    () =>
+      processLinkedIssues(
+        'kynd-no',
+        'kynd-web',
+        [10, 20, 30, 40],
+        pullRequest,
+        { blockedLabels: new Set() },
+        processIssueStub,
+      ),
+    /Issue hygiene failed for 2 issue\(s\): #20, #40/,
+  );
+
+  assert.deepEqual(attemptedIssues, [10, 20, 30, 40]);
+});

--- a/.github/workflows/issue-hygiene-on-merge.yml
+++ b/.github/workflows/issue-hygiene-on-merge.yml
@@ -1,0 +1,38 @@
+name: Issue Hygiene
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  repository-projects: write
+
+jobs:
+  sync-linked-issues:
+    name: Sync Linked Issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sync issue hygiene after merge
+        env:
+          # Optional repository variables:
+          # ISSUE_HYGIENE_BASE_BRANCHES=main,overhaul
+          # ISSUE_HYGIENE_BLOCKED_LABELS=blocked,blocked-by-dependency
+          # ISSUE_HYGIENE_PROJECT_OWNER=kynd
+          # ISSUE_HYGIENE_PROJECT_NUMBER=1
+          # ISSUE_HYGIENE_STATUS_FIELD_NAME=Status
+          # ISSUE_HYGIENE_DONE_OPTION_NAME=Done
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_HYGIENE_BASE_BRANCHES: ${{ vars.ISSUE_HYGIENE_BASE_BRANCHES }}
+          ISSUE_HYGIENE_BLOCKED_LABELS: ${{ vars.ISSUE_HYGIENE_BLOCKED_LABELS }}
+          ISSUE_HYGIENE_PROJECT_OWNER: ${{ vars.ISSUE_HYGIENE_PROJECT_OWNER }}
+          ISSUE_HYGIENE_PROJECT_NUMBER: ${{ vars.ISSUE_HYGIENE_PROJECT_NUMBER }}
+          ISSUE_HYGIENE_STATUS_FIELD_NAME: ${{ vars.ISSUE_HYGIENE_STATUS_FIELD_NAME }}
+          ISSUE_HYGIENE_DONE_OPTION_NAME: ${{ vars.ISSUE_HYGIENE_DONE_OPTION_NAME }}
+        run: node .github/scripts/issue-hygiene-on-merge.mjs


### PR DESCRIPTION
## Summary
- add a shared Cursor rule and PR template so issue hygiene becomes an explicit part of completion instead of chat-only follow-up
- add a post-merge workflow that closes explicitly linked issues, removes stale blocker labels, and comments with merge context
- support optional GitHub Project status sync via repository variables while keeping `overhaul` as a valid delivered-work branch

## Test plan
- [x] `node --check .github/scripts/issue-hygiene-on-merge.mjs`
- [x] Reviewed changed files for workflow and template correctness
- [ ] Live GitHub workflow run after merging a PR with linked issues

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated post-merge workflow that can close issues, remove labels, and update GitHub Project status via API calls; mis-parsed references or misconfiguration could cause unintended issue/project updates.
> 
> **Overview**
> Adds **issue hygiene guardrails** via a new PR template and a shared Cursor rule to encourage explicit linking/closing of delivered issues.
> 
> Introduces a new GitHub Actions workflow (`issue-hygiene-on-merge.yml`) and Node script (`issue-hygiene-on-merge.mjs`) that, on merged PRs to configured base branches (default `main` and `overhaul`), parses closing keywords in the PR title/body to find issue numbers, then auto-closes those issues, removes configured *blocked* labels, optionally sets the linked GitHub Project `Status` to `Done`, and leaves an audit comment with the merge target and PR link. Includes a small node test suite validating closing-reference parsing and per-issue failure aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c04f1b46df3ffd2da9a7c4007c2c67952e1021b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->