### PR TITLE
[page-services] Rebuild Services page from Stitch

### DIFF
--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -95,20 +95,22 @@ const collaborationConsequences = [
     heading="Hva vi faktisk gjør"
     subheading="Vi går inn der erfarne folk gir størst forskjell, både i leveranse og retning."
   >
-    <div class="u-grid-cards u-grid-cards--2">
+    <ul class="services-bento" aria-label="Tjenesteområder">
       {
-        services.map((service) => (
-          <ServiceCard
-            title={service.title}
-            description={service.description}
-            outcome={service.outcome}
-            variant="surface-low"
-          >
-            <span slot="icon">{service.icon}</span>
-          </ServiceCard>
+        services.map((service, index) => (
+          <li class:list={['services-bento-item', { featured: index === 0 || index === 3 }]}>
+            <ServiceCard
+              title={service.title}
+              description={service.description}
+              outcome={service.outcome}
+              variant="surface-low"
+            >
+              <span slot="icon">{service.icon}</span>
+            </ServiceCard>
+          </li>
         ))
       }
-    </div>
+    </ul>
   </PageSection>
 
   <PageSection
@@ -133,12 +135,44 @@ const collaborationConsequences = [
   </PageSection>
 
   <FullBleed variant="surface-low">
-    <ContactCTA variant="dark" />
+    <div class="cta-shell">
+      <ContactCTA variant="dark" />
+    </div>
   </FullBleed>
 </Layout>
 
 <style>
+  .services-bento {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+
+    @media (--md) {
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      gap: 1.5rem;
+    }
+  }
+
+  .services-bento-item {
+    @media (--md) {
+      grid-column: span 3;
+    }
+  }
+
+  .services-bento-item.featured {
+    @media (--md) {
+      grid-column: span 4;
+    }
+  }
+
   .u-list-disc {
     margin: 0;
+  }
+
+  .cta-shell {
+    max-inline-size: 58rem;
+    margin-inline: auto;
   }
 </style>


### PR DESCRIPTION
## Summary
- rebuild `src/pages/tjenester.astro` with a bento-like services card composition
- keep `ServiceCard` reusable API intact and add layout behavior at page level
- contain the dark CTA inside a bounded shell to better match the Stitch intent

## Linked Issues
- Closes #36
- Related: #29

## Issue Hygiene
- [x] Any fully delivered issue is linked with a closing keyword.
- [x] Any partially addressed issue is called out with remaining scope.
- [ ] Issue labels, blockers, and project status were updated, or are not applicable.

## Testing
- [x] `pnpm check`
- [x] Manual verification completed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/layout-only changes confined to `src/pages/tjenester.astro`, with no data, auth, or backend logic touched.
> 
> **Overview**
> Updates `src/pages/tjenester.astro` to render the services list as a semantic `ul` grid with per-item styling, including “featured” cards that span more columns at `--md` breakpoints.
> 
> Adjusts the bottom CTA section by wrapping `ContactCTA` in a constrained `.cta-shell`, and adds the page-level CSS needed for the new grid and CTA sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a4ac485d165d76134d3a0beeccc7428f5fa27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->