### PR TITLE
[page-projects] Rebuild Projects page from Stitch

### DIFF
--- a/src/pages/prosjekter/index.astro
+++ b/src/pages/prosjekter/index.astro
@@ -24,6 +24,10 @@ const categories = [
     .map(([value, count]) => ({ label: value, value, count })),
 ];
 const categoryValues = categories.map((category) => category.value);
+const queryParam = 'kategori';
+const rawActiveCategory = Astro.url.searchParams.get(queryParam);
+const activeCategory =
+  rawActiveCategory && categoryValues.includes(rawActiveCategory) ? rawActiveCategory : 'all';
 const projectPrinciples = [
   'Vi jobber i spenn mellom produkt, teknologi og organisasjon.',
   'Vi prioriterer varig effekt over kortsiktig output.',
@@ -59,12 +63,11 @@ const projectPrinciples = [
     heading="Utvalgte prosjekter"
     subheading="Filtrer på fagområde for å se relevante caser."
   >
-    <CategoryFilter categories={categories} queryParam="kategori" />
+    <CategoryFilter categories={categories} queryParam={queryParam} active={activeCategory} />
     <ProjectGrid projects={projects} />
   </PageSection>
-  <script is:inline define:vars={{ categoryValues }}>
+  <script is:inline define:vars={{ categoryValues, queryParam }}>
     (() => {
-      const queryParam = 'kategori';
       const validCategories = new Set(categoryValues);
       const chips = Array.from(document.querySelectorAll('[data-category-value]'));
       const projectCards = Array.from(document.querySelectorAll('[data-project-tags]'));
@@ -79,6 +82,18 @@ const projectPrinciples = [
       const getActiveCategory = () => {
         const params = new URLSearchParams(window.location.search);
         return normalizeCategory(params.get(queryParam));
+      };
+
+      const setActiveCategory = (category) => {
+        const normalized = normalizeCategory(category);
+        const nextUrl = new URL(window.location.href);
+        if (normalized === 'all') {
+          nextUrl.searchParams.delete(queryParam);
+        } else {
+          nextUrl.searchParams.set(queryParam, normalized);
+        }
+        window.history.pushState({}, '', nextUrl);
+        applyCategory();
       };
 
       const getCardTags = (card) => {
@@ -122,6 +137,14 @@ const projectPrinciples = [
       };
 
       applyCategory();
+      for (const chip of chips) {
+        chip.addEventListener('click', (event) => {
+          if (event.defaultPrevented) return;
+          const value = chip.getAttribute('data-category-value') ?? 'all';
+          event.preventDefault();
+          setActiveCategory(value);
+        });
+      }
       window.addEventListener('popstate', applyCategory);
     })();
   </script>


### PR DESCRIPTION
## Summary
- update `src/pages/prosjekter/index.astro` to keep category state coherent between SSR and client
- preserve filter/gallery behavior while adding chip click handling with URL `pushState`
- keep progressive enhancement by retaining query-parameter based filtering semantics

## Linked Issues
- Closes #37
- Related: #29

## Issue Hygiene
- [x] Any fully delivered issue is linked with a closing keyword.
- [x] Any partially addressed issue is called out with remaining scope.
- [ ] Issue labels, blockers, and project status were updated, or are not applicable.

## Testing
- [x] `pnpm check`
- [x] Manual verification completed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to client-side filtering and URL query handling on the Projects page; main risk is regressions in back/forward navigation or link semantics.
> 
> **Overview**
> Ensures the Projects page category filter has a single source of truth via the `kategori` query param, deriving `activeCategory` during SSR and passing it into `CategoryFilter` so the correct chip is highlighted on first render.
> 
> Adds client-side chip click handling that prevents full-page navigation, updates the URL with `history.pushState`, and reapplies filtering/layout so the gallery stays in sync while still supporting `popstate` (back/forward) behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f78a8f09974bd03ade4161f5e92ee6325fce6df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->