### PR TITLE
Fix careers bento card height

### DIFF
--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -213,6 +213,7 @@ const builderMindsetCards = [
     box-shadow: var(--shadow);
     display: grid;
     gap: 1rem;
+    height: 100%;
   }
 
   .careers-card h3 {


### PR DESCRIPTION
## Summary
- ensure `.careers-card` fills the full height of its stretched bento grid cell on `src/pages/bli-en-av-oss.astro`
- keep borders, background, and shadow aligned when adjacent cards have different content heights

## Test plan
- [x] `pnpm exec prettier --check src/pages/bli-en-av-oss.astro --plugin=prettier-plugin-astro`
- [x] Checked lints for `src/pages/bli-en-av-oss.astro`
- [ ] Manual visual verification in browser

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only tweak on a single page; main risk is minor layout regressions in the `careers` bento section across breakpoints.
> 
> **Overview**
> Ensures the careers “bento” cards visually align by forcing `.careers-card` to stretch to the full height of its grid cell (`height: 100%`) on `src/pages/bli-en-av-oss.astro`.
> 
> This keeps borders/background/shadows consistent when adjacent cards have different content heights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca4e14bab3c78898f57e82f1acecad5f09ab177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->