### PR TITLE
Extend issue hygiene with related issue and parent epic support

### DIFF
--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -1,3 +1,5 @@
+/* global console, fetch, process */
+
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
@@ -66,6 +68,15 @@ function createIssueReferenceConfig(owner, repo) {
   };
 }
 
+function addIssueNumbers(refs, references, extractIssueNumber) {
+  for (const reference of references) {
+    const issueNumber = extractIssueNumber(reference);
+    if (issueNumber !== null) {
+      refs.add(issueNumber);
+    }
+  }
+}
+
 export function parseClosingIssueNumbers(text, owner, repo) {
   const refs = new Set();
   const { issueReferenceSource, extractIssueNumber } = createIssueReferenceConfig(owner, repo);
@@ -77,14 +88,44 @@ export function parseClosingIssueNumbers(text, owner, repo) {
   for (const line of text.split(/\r?\n/)) {
     for (const clauseMatch of line.matchAll(closingClausePattern)) {
       const references = clauseMatch[1].match(new RegExp(issueReferenceSource, 'gi')) || [];
-
-      for (const reference of references) {
-        const issueNumber = extractIssueNumber(reference);
-        if (issueNumber !== null) {
-          refs.add(issueNumber);
-        }
-      }
+      addIssueNumbers(refs, references, extractIssueNumber);
     }
+  }
+
+  return [...refs];
+}
+
+export function parseRelatedIssueNumbers(text, owner, repo) {
+  const refs = new Set();
+  const { issueReferenceSource, extractIssueNumber } = createIssueReferenceConfig(owner, repo);
+  const relatedClausePattern = new RegExp(
+    String.raw`\b(?:related|parent(?:\s+epic)?)\b\s*:?\s*((?:${issueReferenceSource})(?:\s*(?:,\s*|(?:and|or)\s+)(?:${issueReferenceSource}))*)`,
+    'gi',
+  );
+
+  for (const line of text.split(/\r?\n/)) {
+    for (const clauseMatch of line.matchAll(relatedClausePattern)) {
+      const references = clauseMatch[1].match(new RegExp(issueReferenceSource, 'gi')) || [];
+      addIssueNumbers(refs, references, extractIssueNumber);
+    }
+  }
+
+  return [...refs];
+}
+
+export function parseTaskListIssueNumbers(text, owner, repo) {
+  const refs = new Set();
+  const { issueReferenceSource, extractIssueNumber } = createIssueReferenceConfig(owner, repo);
+  const taskListPattern = /^\s*[-*]\s+\[(?: |x|X)\]\s+(.*)$/;
+
+  for (const line of text.split(/\r?\n/)) {
+    const taskMatch = line.match(taskListPattern);
+    if (!taskMatch) {
+      continue;
+    }
+
+    const references = taskMatch[1].match(new RegExp(issueReferenceSource, 'gi')) || [];
+    addIssueNumbers(refs, references, extractIssueNumber);
   }
 
   return [...refs];
@@ -311,8 +352,12 @@ async function addComment(owner, repo, issueNumber, body) {
   });
 }
 
+async function fetchIssue(owner, repo, issueNumber) {
+  return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`);
+}
+
 async function processIssue(owner, repo, issueNumber, pullRequest, config) {
-  const issue = await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`);
+  const issue = await fetchIssue(owner, repo, issueNumber);
 
   if (issue.pull_request) {
     log(`#${issueNumber} is a pull request, not an issue; skipping.`);
@@ -396,6 +441,60 @@ export async function processLinkedIssues(
   }
 }
 
+export async function processReadyRelatedIssues(
+  owner,
+  repo,
+  relatedIssueNumbers,
+  pullRequest,
+  config,
+  { loadIssueFn = fetchIssue, processIssueFn = processIssue } = {},
+) {
+  const seenIssueNumbers = new Set();
+
+  for (const issueNumber of relatedIssueNumbers) {
+    if (seenIssueNumbers.has(issueNumber)) {
+      continue;
+    }
+
+    seenIssueNumbers.add(issueNumber);
+
+    const issue = await loadIssueFn(owner, repo, issueNumber);
+
+    if (issue.pull_request) {
+      log(`#${issueNumber} is a pull request, not an issue; skipping related issue sync.`);
+      continue;
+    }
+
+    if (issue.state === 'closed') {
+      log(`#${issueNumber} is already closed; skipping related issue sync.`);
+      continue;
+    }
+
+    const taskListIssueNumbers = parseTaskListIssueNumbers(issue.body || '', owner, repo);
+    if (taskListIssueNumbers.length === 0) {
+      log(`#${issueNumber} has no issue task list; skipping related issue sync.`);
+      continue;
+    }
+
+    let allTaskListIssuesClosed = true;
+
+    for (const taskListIssueNumber of taskListIssueNumbers) {
+      const taskIssue = await loadIssueFn(owner, repo, taskListIssueNumber);
+      if (taskIssue.state !== 'closed') {
+        allTaskListIssuesClosed = false;
+        break;
+      }
+    }
+
+    if (!allTaskListIssuesClosed) {
+      log(`#${issueNumber} still has open checklist issues; skipping related issue sync.`);
+      continue;
+    }
+
+    await processIssueFn(owner, repo, issueNumber, pullRequest, config);
+  }
+}
+
 export async function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
@@ -429,9 +528,14 @@ export async function main() {
     owner,
     repo,
   );
+  const relatedIssueNumbers = parseRelatedIssueNumbers(
+    `${pullRequest.title || ''}\n${pullRequest.body || ''}`,
+    owner,
+    repo,
+  ).filter((issueNumber) => !linkedIssueNumbers.includes(issueNumber));
 
-  if (linkedIssueNumbers.length === 0) {
-    log('No closing issue references found in the merged PR.');
+  if (linkedIssueNumbers.length === 0 && relatedIssueNumbers.length === 0) {
+    log('No closing or related issue references found in the merged PR.');
     return;
   }
 
@@ -448,6 +552,7 @@ export async function main() {
   };
 
   await processLinkedIssues(owner, repo, linkedIssueNumbers, pullRequest, config);
+  await processReadyRelatedIssues(owner, repo, relatedIssueNumbers, pullRequest, config);
 }
 
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/.github/scripts/issue-hygiene-on-merge.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.mjs
@@ -495,6 +495,45 @@ export async function processReadyRelatedIssues(
   }
 }
 
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function processIssueGroups(
+  owner,
+  repo,
+  linkedIssueNumbers,
+  relatedIssueNumbers,
+  pullRequest,
+  config,
+  {
+    processLinkedIssuesFn = processLinkedIssues,
+    processReadyRelatedIssuesFn = processReadyRelatedIssues,
+  } = {},
+) {
+  const groupFailures = [];
+
+  try {
+    await processLinkedIssuesFn(owner, repo, linkedIssueNumbers, pullRequest, config);
+  } catch (error) {
+    const message = toErrorMessage(error);
+    fail(`Linked issue sync failed: ${message}`);
+    groupFailures.push(`linked issues: ${message}`);
+  }
+
+  try {
+    await processReadyRelatedIssuesFn(owner, repo, relatedIssueNumbers, pullRequest, config);
+  } catch (error) {
+    const message = toErrorMessage(error);
+    fail(`Related issue sync failed: ${message}`);
+    groupFailures.push(`related issues: ${message}`);
+  }
+
+  if (groupFailures.length > 0) {
+    throw new Error(`Issue hygiene had failures in ${groupFailures.join('; ')}`);
+  }
+}
+
 export async function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
@@ -551,8 +590,14 @@ export async function main() {
     statusFieldName: process.env.ISSUE_HYGIENE_STATUS_FIELD_NAME?.trim() || 'Status',
   };
 
-  await processLinkedIssues(owner, repo, linkedIssueNumbers, pullRequest, config);
-  await processReadyRelatedIssues(owner, repo, relatedIssueNumbers, pullRequest, config);
+  await processIssueGroups(
+    owner,
+    repo,
+    linkedIssueNumbers,
+    relatedIssueNumbers,
+    pullRequest,
+    config,
+  );
 }
 
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/.github/scripts/issue-hygiene-on-merge.test.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.test.mjs
@@ -5,6 +5,7 @@ import {
   parseClosingIssueNumbers,
   parseRelatedIssueNumbers,
   parseTaskListIssueNumbers,
+  processIssueGroups,
   processLinkedIssues,
   processReadyRelatedIssues,
 } from './issue-hygiene-on-merge.mjs';
@@ -115,4 +116,66 @@ test('processReadyRelatedIssues closes a related parent once every checklist iss
   );
 
   assert.deepEqual(processedIssues, [29]);
+});
+
+test('processIssueGroups still processes related issues when linked processing fails', async () => {
+  const callOrder = [];
+  const pullRequest = {
+    base: { ref: 'overhaul' },
+    html_url: 'https://github.com/kynd-no/kynd-web/pull/123',
+    number: 123,
+  };
+
+  await assert.rejects(
+    () =>
+      processIssueGroups(
+        'kynd-no',
+        'kynd-web',
+        [10],
+        [29],
+        pullRequest,
+        { blockedLabels: new Set() },
+        {
+          processLinkedIssuesFn: async () => {
+            callOrder.push('linked');
+            throw new Error('linked failure');
+          },
+          processReadyRelatedIssuesFn: async () => {
+            callOrder.push('related');
+          },
+        },
+      ),
+    /Issue hygiene had failures in linked issues: linked failure/,
+  );
+
+  assert.deepEqual(callOrder, ['linked', 'related']);
+});
+
+test('processIssueGroups reports both linked and related failures together', async () => {
+  const pullRequest = {
+    base: { ref: 'overhaul' },
+    html_url: 'https://github.com/kynd-no/kynd-web/pull/123',
+    number: 123,
+  };
+
+  await assert.rejects(
+    () =>
+      processIssueGroups(
+        'kynd-no',
+        'kynd-web',
+        [10],
+        [29],
+        pullRequest,
+        { blockedLabels: new Set() },
+        {
+          processLinkedIssuesFn: async () => {
+            throw new Error('linked failure');
+          },
+          processReadyRelatedIssuesFn: async () => {
+            throw new Error('related failure');
+          },
+        },
+      ),
+    /Issue hygiene had failures in linked issues: linked failure; related issues: related failure/,
+  );
 });

--- a/.github/scripts/issue-hygiene-on-merge.test.mjs
+++ b/.github/scripts/issue-hygiene-on-merge.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { parseClosingIssueNumbers, processLinkedIssues } from './issue-hygiene-on-merge.mjs';
+import {
+  parseClosingIssueNumbers,
+  parseRelatedIssueNumbers,
+  parseTaskListIssueNumbers,
+  processLinkedIssues,
+  processReadyRelatedIssues,
+} from './issue-hygiene-on-merge.mjs';
 
 test('processLinkedIssues continues after a per-issue failure and reports all failed issue numbers', async () => {
   const attemptedIssues = [];
@@ -48,4 +54,65 @@ test('parseClosingIssueNumbers only closes references directly attached to a clo
   );
 
   assert.deepEqual(closingIssueNumbers, [10, 40, 41, 42]);
+});
+
+test('parseRelatedIssueNumbers only collects explicit related references', () => {
+  const relatedIssueNumbers = parseRelatedIssueNumbers(
+    [
+      'Related: #29 and kynd-no/kynd-web#30',
+      'Parent epic: https://github.com/kynd-no/kynd-web/issues/31',
+      'See #32 for context.',
+    ].join('\n'),
+    'kynd-no',
+    'kynd-web',
+  );
+
+  assert.deepEqual(relatedIssueNumbers, [29, 30, 31]);
+});
+
+test('parseTaskListIssueNumbers only reads issue references from markdown task lists', () => {
+  const taskListIssueNumbers = parseTaskListIssueNumbers(
+    [
+      '- [x] #35 [page-home] Rebuild Home page from Stitch',
+      '- [ ] kynd-no/kynd-web#36 [page-services] Rebuild Services page from Stitch',
+      'Blocked by: #29',
+    ].join('\n'),
+    'kynd-no',
+    'kynd-web',
+  );
+
+  assert.deepEqual(taskListIssueNumbers, [35, 36]);
+});
+
+test('processReadyRelatedIssues closes a related parent once every checklist issue is closed', async () => {
+  const processedIssues = [];
+  const pullRequest = {
+    base: { ref: 'overhaul' },
+    html_url: 'https://github.com/kynd-no/kynd-web/pull/123',
+    number: 123,
+  };
+  const issueMap = {
+    29: {
+      body: ['- [x] #35', '- [x] #36'].join('\n'),
+      state: 'open',
+    },
+    35: { body: '', state: 'closed' },
+    36: { body: '', state: 'closed' },
+  };
+
+  await processReadyRelatedIssues(
+    'kynd-no',
+    'kynd-web',
+    [29],
+    pullRequest,
+    { blockedLabels: new Set() },
+    {
+      loadIssueFn: async (_owner, _repo, issueNumber) => issueMap[issueNumber],
+      processIssueFn: async (_owner, _repo, issueNumber) => {
+        processedIssues.push(issueNumber);
+      },
+    },
+  );
+
+  assert.deepEqual(processedIssues, [29]);
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,10 @@ To keep PRs small and manageable:
 3. **PR C (Polish and follow-up fixes)**  
    `4a8c746`
 
-After these, the branch is ready for content/IA-focused PR slices aligned with `OVERHAUL.md`:
+After these, the branch is ready for content/IA-focused PR slices tracked in [#69 Epic: Content + IA Overhaul](https://github.com/kyndig/kynd-web/issues/69):
 
-- Forside positioning rewrite
-- Tjenester (for/not-for fit)
-- Hvordan vi jobber
-- Om Kynd + Join/Kultur separation
-- Kontakt conversion flow
+- [#70](https://github.com/kyndig/kynd-web/issues/70) Home positioning rewrite
+- [#71](https://github.com/kyndig/kynd-web/issues/71) Services fit and offer clarity
+- [#72](https://github.com/kyndig/kynd-web/issues/72) Hvordan vi jobber page direction
+- [#73](https://github.com/kyndig/kynd-web/issues/73) Om Kynd and join/culture separation
+- [#74](https://github.com/kyndig/kynd-web/issues/74) Contact conversion flow


### PR DESCRIPTION
## Summary

- Adds `parseRelatedIssueNumbers` to detect `Related:` and `Parent epic:` references in PR bodies.
- Adds `parseTaskListIssueNumbers` to read issue references from markdown task lists in issue bodies.
- Adds `processReadyRelatedIssues`, which auto-closes a related issue once every issue in its task list is closed. This means parent epics (like #69) will self-close when all child issues are delivered, without needing an explicit closing keyword on the PR.
- Extracts `addIssueNumbers` and `fetchIssue` as shared helpers — DRY reduction across the three parser functions.
- Links the CHANGELOG.md next-phase backlog entries to the newly created GitHub issues (#69–#74) so the markdown is no longer the only source of truth.

## Linked Issues

- Related: #69

## Issue Hygiene

- [x] Any fully delivered issue is linked with a closing keyword.
- [x] Any partially addressed issue is called out with remaining scope.
- [x] Issue labels, blockers, and project status were updated, or are not applicable.

## Testing

- [x] `pnpm check`
- [x] New tests cover `parseRelatedIssueNumbers`, `parseTaskListIssueNumbers`, and `processReadyRelatedIssues` with stubs — no live API calls required.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes post-merge automation that can close issues and update labels/project status; parsing mistakes or unexpected issue bodies could lead to unintended issue updates.
> 
> **Overview**
> Merged-PR issue hygiene now recognizes **explicit related references** (e.g. `Related:` / `Parent epic:`) in PR titles/bodies, in addition to closing-keyword references.
> 
> For related issues, it adds a readiness check that parses **markdown task lists** in the related issue body and only runs the normal close/label/project-sync workflow once *all referenced checklist issues are already closed*. Linked and related processing are now orchestrated via `processIssueGroups`, so failures in one group don’t prevent attempting the other while still surfacing a combined error.
> 
> Documentation is updated to link the overhaul backlog items to GitHub issues (#69–#74), and tests cover the new parsers and related-issue processing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4bde7c7a30c991b1c634bb6d48213fd0a4dbc59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->