### PR TITLE
Implement content and IA overhaul across primary routes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
+      // IA decisions: only canonical public routes should be indexed.
       filter: (page) =>
         !page.includes('/om-oss') &&
         !page.includes('/hvordan-vi-jobber') &&

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -10,8 +10,8 @@ type Props = {
 };
 
 const {
-  title = 'Klar for en prat?',
-  body = 'Ikke helt sikker på hva du trenger ennå? Det går fint. Vi tar en uforpliktende samtale.',
+  title = 'Ta en prat med oss',
+  body = 'Uforpliktende første møte. Ikke helt sikker på hva du trenger ennå? Det går fint.',
   href = '/kontakt',
   ctaLabel = 'Ta en prat med oss',
   variant = 'default',

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const {
-  title = 'Ta en prat med oss',
+  title = 'Vil du ta en prat med oss?',
   body = 'Uforpliktende første møte. Ikke helt sikker på hva du trenger ennå? Det går fint.',
   href = '/kontakt',
   ctaLabel = 'Ta en prat med oss',

--- a/src/components/ContactUs.astro
+++ b/src/components/ContactUs.astro
@@ -37,7 +37,7 @@ import TextArea from './TextArea.astro';
       <Button type="submit">Send</Button>
     </form>
     <p class="next-step">
-      Etter innsending tar vi kontakt for en kort avklaring av behov, og foreslar en konkret videre
+      Etter innsending tar vi kontakt for en kort avklaring av behov, og foreslår en konkret videre
       prosess.
     </p>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,9 +20,10 @@ import Logo from './Logo.astro';
       <a href="/tjenester">Tjenester</a>
       <a href="/prosjekter">Prosjekter</a>
       <a href="/om-kynd">Om Kynd</a>
+      <a href="/kontakt">Ta en prat</a>
       <a href="/folka">Folka</a>
       <a href="/bli-en-av-oss">Bli en av oss</a>
-      <a href="/bok">Håndbok</a>
+      <a href="/bok">Håndbok (fordypning)</a>
     </div>
     <div class="list">
       <div class="list-header">Sosiale medier</div>

--- a/src/pages/bli-en-av-oss.astro
+++ b/src/pages/bli-en-av-oss.astro
@@ -87,7 +87,7 @@ const builderMindsetCards = [
 
 <Layout
   title="Bli en av oss"
-  description="Kynd er for folk som vil bygge, ikke bare føre timer. Les om eierskap, faglig tyngde og hva vi ser etter i nye kolleger."
+  description="Kynd er for folk som vil bygge, ikke bare føre timer. Les om eierskap, seleksjon og hva vi ser etter i nye kolleger."
   image="/patterns/pattern-2.svg"
 >
   <HeroSection
@@ -120,8 +120,8 @@ const builderMindsetCards = [
   </PageSection>
 
   <PageSection
-    heading="Dating og invitasjon"
-    subheading="Rekrutteringsprosessen handler om gjensidig vurdering av verdi, tillit og samarbeid."
+    heading="Prosess: avklaring før invitasjon"
+    subheading="Rekrutteringsløpet handler om gjensidig vurdering av verdi, tillit og samarbeid."
   >
     <Split minBreakpoint="md" gap="2rem">
       <Prose wide slot="left">
@@ -176,7 +176,7 @@ const builderMindsetCards = [
 
   <ContactCTA
     title="Nysgjerrig på Kynd?"
-    body="Send en kort melding om deg selv og hva du vil bygge. Vi svarer med et konkret forslag til neste steg."
+    body="Send en kort melding om deg selv og hva du vil bygge. Vi svarer med et uforpliktende forslag til neste steg."
   />
 </Layout>
 

--- a/src/pages/hvordan-vi-jobber.astro
+++ b/src/pages/hvordan-vi-jobber.astro
@@ -1,3 +1,5 @@
 ---
+// IA decision (#72): this route stays absorbed into /tjenester.
+// Keep a permanent redirect so legacy links keep working.
 return Astro.redirect('/tjenester', 301);
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ const collaborationStyle = [
     image="/patterns/pattern-0.svg"
   />
   <PageSection
-    heading="Hva Kynd er i praksis"
+    heading="Hva er Kynd?"
     subheading="Vi er et produktmiljø for selskaper som trenger både fremdrift og gode beslutninger."
   >
     <Split minBreakpoint="md" gap="2rem" columns="1.15fr 0.85fr">
@@ -71,7 +71,7 @@ const collaborationStyle = [
     </Split>
   </PageSection>
   <PageSection
-    heading="Hva Kynd er"
+    heading="Kjennetegn ved Kynd"
     subheading="Et fellesskap av erfarne folk som kombinerer produktblikk, teknologiforståelse og gjennomføring."
   >
     <ul class="u-grid-cards u-grid-cards--3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,33 +13,33 @@ import { getProjectsWithDuration } from '@/utils/projectHelpers';
 const projects = await getProjectsWithDuration();
 const featuredProjects = projects.slice(0, 3);
 const keyConcepts = [
-  'Produkt, teknologi og organisasjon henger sammen.',
-  'Vi fungerer både i nye initiativer og etablerte produktmiljøer.',
-  'Du får erfarne folk med skapertrang og gjennomføringsevne.',
+  'Produkt, teknologi og organisasjon henger sammen',
+  'Vi fungerer både i nye initiativer og etablerte miljøer',
+  'Erfarne folk med skapertrang og gjennomføringsevne',
 ];
 const manifestoPoints = [
   'Vi går inn i krevende beslutninger, ikke bare oppgaver.',
-  'Vi kobler strategi, produkt og teknologi i samme arbeidsloop.',
+  'Vi kobler strategi, produkt og teknologi i samme arbeidsløp.',
   'Vi bygger fart uten å skyve teknisk og organisatorisk gjeld foran oss.',
 ];
 const helpAreas = [
   'Utforske nye idéer og komme raskt til en MVP.',
-  'Forbedre eksisterende produkter uten å skape mer kompleksitet.',
+  'Forbedre eksisterende produkter uten å skape unødvendig kompleksitet.',
   'Ta teknologivalg som holder over tid i drift, team og forretning.',
   'Styrke produkt- og teamledelse når retning og prioritering glipper.',
-  'Koble strategi, produkt og gjennomføring i samme arbeidsløp.',
-  'Skalere systemer og samarbeid uten å miste fart eller kvalitet.',
+  'Koble strategi, produkt og gjennomføring i samme løp.',
+  'Støtte team som trenger mer fremdrift uten å miste kvalitet.',
 ];
 const collaborationStyle = [
-  'Vi sier tydelig fra når antakelser ikke holder, tidlig i prosessen.',
-  'Vi jobber tett med beslutningstakerne, ikke i et side-spor.',
-  'Vi tar ansvar for resultatet sammen med teamet, ikke bare leveransen.',
+  'Vi avklarer mål og risiko tidlig, så beslutninger tas på riktig grunnlag.',
+  'Vi jobber tett med beslutningstakere og team, ikke i et side-spor.',
+  'Vi tar ansvar for resultatet sammen med dere, ikke bare leveransen.',
 ];
 ---
 
 <Layout
   title="Nysgjerrige hoder. Erfarne hender."
-  description="Kynd er et fellesskap for produktutvikling. Vi hjelper med teknologi, produkt, organisasjon og gjennomføring i både nye initiativer og etablerte produktmiljøer."
+  description="Kynd er et fellesskap for produktutvikling. Vi hjelper med teknologi, produkt, organisasjon og gjennomføring i både nye initiativer og etablerte miljøer."
   image="/patterns/pattern-0.svg"
 >
   <HeroSection
@@ -51,15 +51,15 @@ const collaborationStyle = [
     image="/patterns/pattern-0.svg"
   />
   <PageSection
-    heading="Manifest og arbeidsform"
-    subheading="Vi er et produktmiljø for selskaper som trenger både fremdrift og solide beslutninger."
+    heading="Hva Kynd er i praksis"
+    subheading="Vi er et produktmiljø for selskaper som trenger både fremdrift og gode beslutninger."
   >
     <Split minBreakpoint="md" gap="2rem" columns="1.15fr 0.85fr">
       <div slot="left" class="manifesto-copy">
         <p>
           Kynd ble etablert for å bygge verdi i skjæringen mellom produkt, teknologi og
-          organisasjon. Vi tar ansvar i hele løpet: fra utforsking og prioritering til produksjon og
-          videre drift.
+          organisasjon. Vi tar ansvar i hele løpet: fra utforsking og prioritering til
+          implementering og videre drift.
         </p>
         <ul class="u-list-disc">
           {manifestoPoints.map((point) => <li>{point}</li>)}
@@ -93,7 +93,7 @@ const collaborationStyle = [
     </ul>
   </PageSection>
   <PageSection
-    heading="Utvalgte samarbeid"
+    heading="Bevis i praksis"
     subheading="Noen av prosjektene som viser hvordan vi kobler problem, innsats og effekt."
   >
     <Split minBreakpoint="md" gap="2rem" columns="1.1fr 0.9fr">
@@ -116,14 +116,18 @@ const collaborationStyle = [
   </PageSection>
   <PageSection
     heading="Slik er det å jobbe med oss"
-    subheading="Målet er lav friksjon, tydelighet og fremdrift fra første uke."
+    subheading="Lav friksjon, tydelighet og fremdrift fra første uke."
   >
     <ul class="u-grid-cards u-grid-cards--3">
       {collaborationStyle.map((style) => <li class="text-card">{style}</li>)}
     </ul>
   </PageSection>
   <FullBleed variant="dark">
-    <ContactCTA variant="dark" />
+    <ContactCTA
+      variant="dark"
+      title="Ta en prat med oss"
+      body="Uforpliktende første møte. Vi avklarer hva dere trenger, og foreslår et konkret neste steg."
+    />
   </FullBleed>
 </Layout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -125,7 +125,6 @@ const collaborationStyle = [
   <FullBleed variant="dark">
     <ContactCTA
       variant="dark"
-      title="Ta en prat med oss"
       body="Uforpliktende første møte. Vi avklarer hva dere trenger, og foreslår et konkret neste steg."
     />
   </FullBleed>

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -1,17 +1,43 @@
 ---
 import ContactUs from '@/components/ContactUs.astro';
 import HeroSection from '@/components/HeroSection.astro';
+import PageSection from '@/components/PageSection.astro';
+import Prose from '@/components/Prose.astro';
+import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
+
+const nextSteps = [
+  'Vi svarer raskt med forslag til tidspunkt for en kort avklaring.',
+  'I første møte kartlegger vi behov, mål og rammer sammen.',
+  'Etterpå får du et konkret forslag til neste steg - helt uforpliktende.',
+];
 ---
 
 <Layout
   title="Kontakt"
-  description="Ta kontakt med Kynd for en uforpliktende prat om produktutvikling, teknologi og samarbeid."
+  description="Ta en prat med Kynd om produktutvikling, teknologi og samarbeid. Uforpliktende første møte med tydelig neste steg."
   image="/patterns/pattern-0.svg"
 >
   <HeroSection
-    title="Kontakt"
-    preamble="Vi tar gjerne en uforpliktende prat om utfordringer, muligheter og hva som er riktig neste steg."
+    title="Ta en prat med oss"
+    preamble="Uforpliktende første møte. Vi avklarer behov og foreslår et konkret neste steg."
+    tagline="Kontakt"
   />
+  <PageSection
+    heading="Slik fungerer det"
+    subheading="Lav terskel, tydelig neste steg og ingen krav om ferdig bestilling."
+  >
+    <Split minBreakpoint="md" gap="2rem">
+      <Prose slot="left" wide>
+        <p>
+          Du trenger ikke å vite nøyaktig hva du trenger før du tar kontakt. Bruk meldingsfeltet til
+          å beskrive situasjonen kort, så tar vi det derfra.
+        </p>
+      </Prose>
+      <ul slot="right" class="u-list-disc">
+        {nextSteps.map((step) => <li>{step}</li>)}
+      </ul>
+    </Split>
+  </PageSection>
   <ContactUs />
 </Layout>

--- a/src/pages/om-kynd.astro
+++ b/src/pages/om-kynd.astro
@@ -11,15 +11,15 @@ import Split from '@/components/layout/Split.astro';
 import Layout from '@/layouts/Base.astro';
 
 const coreValues = [
-  'Integritet i tekniske og strategiske anbefalinger.',
-  'Tydelig kommunikasjon fremfor konsulentspråk.',
-  'Ansvar for effekt, ikke bare aktivitet.',
+  'Fellesskap, ikke bare konsulentskall',
+  'Gründertenkning kombinert med senior gjennomføring',
+  'Nøktern og troverdig annerledeshet',
 ];
 ---
 
 <Layout
   title="Om Kynd"
-  description="Kynd ble startet for å bygge et fagmiljø der produkt, teknologi og organisasjon sees i sammenheng. Les om hvorfor vi finnes og hva vi gjør annerledes."
+  description="Kynd er et fellesskap for produktutvikling. Les hvorfor vi finnes, hva vi gjør annerledes, og hvordan vi kombinerer gjennomføring med langsiktig produktambisjon."
   image="/patterns/pattern-1.svg"
 >
   <HeroSection
@@ -30,23 +30,23 @@ const coreValues = [
 
   <PageSection
     heading="Hvorfor Kynd finnes"
-    subheading="Vi reagerte på en bransje der for mye handler om timer, og for lite om faktisk verdi."
+    subheading="Vi reagerte på en bransje der for mye handler om timer, og for lite om effekt."
   >
     <Split minBreakpoint="md" gap="2rem" columns="1.1fr 0.9fr">
       <Prose wide slot="left">
         <p>
           Kynd ble startet for å samle folk som vil ta ansvar for mer enn teknisk leveranse. Vi
-          mener at gode produkter bygges når produkt, teknologi og organisasjon vurderes samtidig,
-          ikke i separate løp.
+          mener at gode produkter bygges når produkt, teknologi og organisasjon vurderes samtidig.
         </p>
         <p>
           Derfor jobber vi tett med team og ledelse der beslutningene tas. Vi utfordrer premisser
-          som ikke holder over tid, og bidrar til valg som gir varig effekt i både produkt og drift.
+          som ikke holder over tid, og bidrar til valg som gir varig effekt i produkt, drift og
+          samarbeid.
         </p>
       </Prose>
       <QuoteBlock
         slot="right"
-        quote="Vi selger ikke kapasitet. Vi går inn i beslutninger som faktisk påvirker kvalitet, fart og verdi over tid."
+        quote="Vi selger ikke kapasitet. Vi går inn i beslutninger som påvirker kvalitet, fart og verdi over tid."
         author="Kynd"
         authorRole="Arbeidsform"
       />
@@ -55,7 +55,7 @@ const coreValues = [
 
   <PageSection
     heading="Hva vi gjør annerledes"
-    subheading="Vi foretrekker tydelighet fremfor konsulentspråk og generiske modeller."
+    subheading="Vi foretrekker tydelighet fremfor konsulentspråk og standardpakker."
   >
     <ul class="u-list-disc">
       <li>Senior kompetanse tett på beslutninger med høy konsekvens.</li>
@@ -83,13 +83,13 @@ const coreValues = [
   <FullBleed variant="dark">
     <PageSection
       heading="Konsulentarbeid og produktambisjon"
-      subheading="Vi bygger verdi for kunder i dag, og bygger også kompetanse og produkter på lang sikt."
+      subheading="Vi bygger verdi for kunder i dag, og bygger samtidig kompetanse og produkter på lang sikt."
     >
       <Prose wide>
         <p>
           Kynd er bygget som et konsulentselskap med ambisjon om å skape mer enn klassisk
-          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker erfaringene
-          til å utvikle egne initiativer over tid.
+          konsulentleveranse. Vi hjelper kunder med å bygge gode produkter, og bruker læringen til å
+          utvikle egne initiativer over tid.
         </p>
         <p>
           Denne kombinasjonen krever nøkternhet, integritet og gjennomføringsevne. Målet er ikke å
@@ -109,7 +109,11 @@ const coreValues = [
   </PageSection>
 
   <FullBleed variant="surface-low">
-    <ContactCTA variant="surface-low" />
+    <ContactCTA
+      variant="surface-low"
+      title="Vil du utforske et samarbeid?"
+      body="Ta en prat med oss. Vi starter med en uforpliktende avklaring av behov, mål og neste steg."
+    />
   </FullBleed>
 </Layout>
 

--- a/src/pages/om-oss.astro
+++ b/src/pages/om-oss.astro
@@ -1,3 +1,5 @@
 ---
+// IA decision (#73): /om-kynd is the canonical company-story route.
+// Keep /om-oss as a permanent redirect for backwards compatibility.
 return Astro.redirect('/om-kynd', 301);
 ---

--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -55,9 +55,9 @@ const services = [
 
 const fit = [
   'Virksomheter som vil få produkt, teknologi og organisasjon til å trekke i samme retning.',
-  'Produktteam som ønsker tydelige prioriteringer og senior dømmekraft i vanskelige valg.',
+  'Produktteam som trenger tydelige prioriteringer og senior dømmekraft i vanskelige valg.',
   'Miljøer som trenger hjelp både operativt og strategisk, tidlig eller sent i løpet.',
-  'Organisasjoner som ønsker samarbeidspartner, ikke ren kapasitetsfylling.',
+  'Organisasjoner som ønsker samarbeidspartner, ikke bare kapasitet.',
 ];
 
 const noFit = [
@@ -82,7 +82,7 @@ const collaborationConsequences = [
 
 <Layout
   title="Tjenester"
-  description="Kynd leverer fullstack-utvikling, produkt- og tjenestedesign, teknologiledelse, organisasjonsdesign, prosjekt- og teamledelse og strategisk rådgivning."
+  description="Kynd hjelper med fullstack-utvikling, design, teknologiledelse, organisasjonsdesign, prosjekt- og teamledelse og strategisk rådgivning."
   image="/patterns/pattern-1.svg"
 >
   <HeroSection
@@ -93,7 +93,7 @@ const collaborationConsequences = [
 
   <PageSection
     heading="Hva vi faktisk gjør"
-    subheading="Vi går inn der erfarne folk gir størst forskjell, både i leveranse og retning."
+    subheading="Vi går inn der erfarne folk gjør størst forskjell, både i leveranse og retning."
   >
     <ul class="services-bento" aria-label="Tjenesteområder">
       {
@@ -114,7 +114,7 @@ const collaborationConsequences = [
   </PageSection>
 
   <PageSection
-    heading="Slik leverer vi"
+    heading="Slik jobber vi med deg"
     subheading="Arbeidsformen er en del av tjenesten. Vi utfordrer tidlig, prioriterer hardt og tar ansvar for konsekvensene."
   >
     <Split minBreakpoint="md" gap="2rem">
@@ -129,14 +129,18 @@ const collaborationConsequences = [
 
   <PageSection
     heading="Hvem vi passer for"
-    subheading="Dette er bevisst selekterende. Riktig match gir bedre resultater for begge parter."
+    subheading="Riktig match gir bedre resultater for begge parter."
   >
     <FitSection fit={fit} noFit={noFit} />
   </PageSection>
 
   <FullBleed variant="surface-low">
     <div class="cta-shell">
-      <ContactCTA variant="dark" />
+      <ContactCTA
+        variant="dark"
+        title="Ta en prat med oss"
+        body="Uforpliktende første møte. Du trenger ikke ha ferdig bestilling før vi snakker sammen."
+      />
     </div>
   </FullBleed>
 </Layout>

--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -138,7 +138,6 @@ const collaborationConsequences = [
     <div class="cta-shell">
       <ContactCTA
         variant="dark"
-        title="Ta en prat med oss"
         body="Uforpliktende første møte. Du trenger ikke ha ferdig bestilling før vi snakker sammen."
       />
     </div>


### PR DESCRIPTION
## Summary
- finalize IA decisions by keeping `/om-kynd` canonical, retaining `/om-oss` and `/hvordan-vi-jobber` as permanent redirects, and documenting sitemap canonical indexing intent
- rewrite core page messaging on Home, Services, Om Kynd, Careers, and Kontakt to align with the overhaul brief's positioning, fit, and conversion goals
- normalize low-friction CTA language via `ContactCTA` defaults and update contact flow copy to clearly explain next steps

## Linked Issues
- Closes #70
- Closes #71
- Closes #72
- Closes #73
- Closes #74
- Closes #69

## Test plan
- [x] `pnpm check`
- [ ] Manually review key routes (`/`, `/tjenester`, `/om-kynd`, `/bli-en-av-oss`, `/kontakt`) for copy hierarchy and CTA consistency


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to copy/IA adjustments, sitemap indexing filters, and permanent redirects; main risk is SEO/navigation impact if canonical/redirect targets are incorrect.
> 
> **Overview**
> **Information architecture + SEO:** Marks `/om-kynd` and `/tjenester` as canonical by keeping `/om-oss` and `/hvordan-vi-jobber` as **permanent 301 redirects**, and updates `astro.config.mjs` sitemap filtering to avoid indexing those legacy routes (plus `/labs`).
> 
> **Content + conversion:** Rewrites/reshapes copy across Home, Services, Careers, About, and Contact to match updated positioning, and standardizes low-friction messaging by updating `ContactCTA` defaults and passing more specific CTA body text from key pages.
> 
> **Contact flow clarity:** Expands `/kontakt` with a new “how it works” section (next steps list) and minor copy fixes in `ContactUs`/footer navigation to better guide users to contacting Kynd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e186801aa5bd1e98b4654892cebf9b5ad774ac9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->