### PR TITLE
Add axe-driven accessibility coverage and interaction checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@axe-core/playwright": "^4.11.1",
     "@csstools/postcss-global-data": "^3.1.0",
     "@eslint/js": "^9.39.1",
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.8
         version: 0.9.8(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.59.1)
       '@csstools/postcss-global-data':
         specifier: ^3.1.0
         version: 3.1.0(postcss@8.5.8)
@@ -153,6 +156,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
+
+  '@axe-core/playwright@4.11.1':
+    resolution: {integrity: sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -5075,6 +5083,11 @@ snapshots:
   '@astrojs/yaml2ts@0.2.3':
     dependencies:
       yaml: 2.8.3
+
+  '@axe-core/playwright@4.11.1(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.2
+      playwright-core: 1.59.1
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/src/components/ContactUs.astro
+++ b/src/components/ContactUs.astro
@@ -140,16 +140,17 @@ import TextArea from './TextArea.astro';
 
       if (error) {
         console.error(error);
-        if (isInputError(error) && formError) {
-          const errorMessage = error.fields.email
-            ?.concat(error.fields.message ?? [])
-            .concat(error.fields.name ?? [])
-            .join(', ');
-          formError.textContent = errorMessage ?? 'Noe gikk galt 😅';
+        if (formError) {
+          const errorMessage = isInputError(error)
+            ? error.fields.email?.concat(error.fields.message ?? []).concat(error.fields.name ?? []).join(', ')
+            : (error as { message?: string })?.message;
+
+          formError.textContent = errorMessage || 'Noe gikk galt 😅';
           formError.style.display = 'block';
-          if (submitButton) {
-            submitButton.textContent = originalText;
-          }
+        }
+
+        if (submitButton) {
+          submitButton.textContent = originalText;
         }
       } else {
         form.reset();

--- a/src/components/ContactUs.astro
+++ b/src/components/ContactUs.astro
@@ -142,7 +142,10 @@ import TextArea from './TextArea.astro';
         console.error(error);
         if (formError) {
           const errorMessage = isInputError(error)
-            ? error.fields.email?.concat(error.fields.message ?? []).concat(error.fields.name ?? []).join(', ')
+            ? error.fields.email
+                ?.concat(error.fields.message ?? [])
+                .concat(error.fields.name ?? [])
+                .join(', ')
             : (error as { message?: string })?.message;
 
           formError.textContent = errorMessage || 'Noe gikk galt 😅';

--- a/src/components/EmployeeGrid.astro
+++ b/src/components/EmployeeGrid.astro
@@ -11,7 +11,7 @@ const employees = await getCollection('employees');
     employees.map(({ data, id }) => (
       <ImageLink
         src={data.image}
-        alt={data.name}
+        alt=""
         name={data.name}
         href={`/folka/${id}`}
         layout="full-width"

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -11,7 +11,7 @@
   --color-light-green: #b9ff66;
   --color-gray: #898989;
   --color-light-gray: #f3f3f3;
-  --color-red: #ff5979;
+  --color-red: #c2183a;
 
   --color-primary: var(--color-dark-blue);
   --color-secondary: var(--color-white);

--- a/tests/e2e/accessibility-interactions.spec.ts
+++ b/tests/e2e/accessibility-interactions.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { assertNoAxeViolations } from './helpers/accessibility';
+
+test('skip link reaches main content landmark', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.keyboard.press('Tab');
+
+  const skipLink = page.getByRole('link', { name: 'Hopp til hovedinnhold' });
+  await expect(skipLink).toBeVisible();
+  await skipLink.click();
+  await expect(page).toHaveURL(/#main-content$/);
+});
+
+test('theme toggle persists in local storage and keeps control state in sync', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const html = page.locator('html');
+  const toggle = page.locator('[data-theme-toggle]').first();
+
+  const initialTheme = await html.getAttribute('data-theme');
+  const nextTheme = initialTheme === 'dark' ? 'light' : 'dark';
+
+  await toggle.click();
+
+  await expect(html).toHaveAttribute('data-theme', nextTheme);
+  await expect(toggle).toHaveAttribute('aria-pressed', nextTheme === 'dark' ? 'true' : 'false');
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(html).toHaveAttribute('data-theme', nextTheme);
+  await expect(toggle).toHaveAttribute('aria-pressed', nextTheme === 'dark' ? 'true' : 'false');
+});
+
+test.describe('mobile navigation drawer', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('opens and closes via escape key', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const menuToggle = page.locator('#mobile-menu-toggle');
+    const drawerMenu = page.locator('#drawer-menu');
+
+    await menuToggle.click();
+    await expect(menuToggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(drawerMenu).toHaveClass(/open/);
+    await assertNoAxeViolations(page, { include: ['#drawer-menu'] });
+
+    await page.keyboard.press('Escape');
+    await expect(menuToggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(drawerMenu).not.toHaveClass(/open/);
+  });
+});

--- a/tests/e2e/accessibility-routes.spec.ts
+++ b/tests/e2e/accessibility-routes.spec.ts
@@ -1,0 +1,20 @@
+import { test } from '@playwright/test';
+import { assertNoAxeViolations } from './helpers/accessibility';
+
+const routeCases = [
+  '/',
+  '/tjenester',
+  '/kontakt',
+  '/prosjekter',
+  '/om-kynd',
+  '/bli-en-av-oss',
+  '/prosjekter/cognite',
+  '/folka/axel',
+];
+
+for (const route of routeCases) {
+  test(`axe: ${route}`, async ({ page }) => {
+    await page.goto(route, { waitUntil: 'domcontentloaded' });
+    await assertNoAxeViolations(page);
+  });
+}

--- a/tests/e2e/contact-form-validation.spec.ts
+++ b/tests/e2e/contact-form-validation.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { assertNoAxeViolations } from './helpers/accessibility';
+
+test('contact form surfaces validation errors in aria-live region', async ({ page }) => {
+  await page.goto('/kontakt', { waitUntil: 'domcontentloaded' });
+
+  const form = page.locator('.contact-form');
+  const errorRegion = page.locator('.form-error');
+
+  await page.evaluate(() => {
+    const formElement = document.querySelector<HTMLFormElement>('.contact-form');
+    if (formElement) {
+      formElement.noValidate = true;
+    }
+  });
+
+  await form.getByRole('button', { name: 'Send' }).click();
+
+  await expect(errorRegion).toBeVisible();
+  await expect(errorRegion).toContainText('Ugyldig e-post');
+  await assertNoAxeViolations(page, { include: ['.contact-form'] });
+});

--- a/tests/e2e/helpers/accessibility.ts
+++ b/tests/e2e/helpers/accessibility.ts
@@ -23,7 +23,7 @@ function formatViolations(
   violations: Array<{
     id: string;
     impact?: string | null;
-    nodes: Array<{ target: string[]; failureSummary?: string | null }>;
+    nodes: Array<{ target: unknown; failureSummary?: string | null }>;
   }>,
 ) {
   if (violations.length === 0) {
@@ -32,7 +32,13 @@ function formatViolations(
 
   return violations
     .map((violation) => {
-      const targets = violation.nodes.map((node) => node.target.join(' > ')).join(', ');
+      const targets = violation.nodes
+        .map((node) =>
+          Array.isArray(node.target)
+            ? node.target.map((targetPart) => String(targetPart)).join(' > ')
+            : String(node.target),
+        )
+        .join(', ');
       const summaries = violation.nodes
         .map((node) => node.failureSummary)
         .filter(Boolean)

--- a/tests/e2e/helpers/accessibility.ts
+++ b/tests/e2e/helpers/accessibility.ts
@@ -1,0 +1,43 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+export async function assertNoAxeViolations(
+  page: Page,
+  {
+    include,
+  }: {
+    include?: string[];
+  } = {},
+) {
+  const builder = new AxeBuilder({ page });
+
+  for (const selector of include || []) {
+    builder.include(selector);
+  }
+
+  const results = await builder.analyze();
+  expect(results.violations, formatViolations(results.violations)).toEqual([]);
+}
+
+function formatViolations(
+  violations: Array<{
+    id: string;
+    impact?: string | null;
+    nodes: Array<{ target: string[]; failureSummary?: string | null }>;
+  }>,
+) {
+  if (violations.length === 0) {
+    return 'No accessibility violations found.';
+  }
+
+  return violations
+    .map((violation) => {
+      const targets = violation.nodes.map((node) => node.target.join(' > ')).join(', ');
+      const summaries = violation.nodes
+        .map((node) => node.failureSummary)
+        .filter(Boolean)
+        .join(' | ');
+      return `${violation.id} (${violation.impact ?? 'no-impact'}): ${targets}${summaries ? ` => ${summaries}` : ''}`;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
## Summary
- add `@axe-core/playwright` plus a shared accessibility helper to keep route and interaction scans DRY
- introduce route-level and interaction-level accessibility specs (skip link, theme persistence, mobile drawer, and contact-form validation)
- fix accessibility defects surfaced by the new suite: redundant employee grid image alt text, non-visible server-action errors in contact form, and low-contrast form error text color

## Test plan
- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm test:e2e`

## Notes
- this PR is stacked on top of #79 and should be reviewed/merged after the Playwright foundation branch.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds test coverage and small accessibility/UI tweaks; low risk aside from potential for flaky e2e expectations around navigation and DOM timing.
> 
> **Overview**
> Adds `@axe-core/playwright` and a shared `assertNoAxeViolations` helper, then introduces new Playwright e2e specs that run axe scans across key routes and verify accessibility-related interactions (skip link, theme toggle persistence/ARIA state, mobile drawer behavior, and contact form error announcements).
> 
> Fixes issues surfaced by the new tests: the contact form now surfaces both input-validation and generic server-action errors in the `.form-error` aria-live region, employee grid images become decorative (`alt=""`), and the error/focus red token is darkened for improved contrast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4829a6a0e7915e2b7d2c0b573785f17e7a75a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->