### PR TITLE
Remove public Daniel traces

### DIFF
--- a/src/components/EmployeeGrid.astro
+++ b/src/components/EmployeeGrid.astro
@@ -2,8 +2,9 @@
 import { getCollection } from 'astro:content';
 import ImageLink from '@/components/ImageLink.astro';
 import LinkGrid from '@/components/LinkGrid.astro';
+import { filterForProduction } from '@/utils/contentVisibility';
 
-const employees = await getCollection('employees');
+const employees = filterForProduction(await getCollection('employees'));
 ---
 
 <LinkGrid>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,7 @@ const employees = defineCollection({
     z.object({
       name: z.string(),
       image: image(),
+      hideFromProduction: z.boolean().optional(),
     }),
 });
 
@@ -30,6 +31,7 @@ const projects = defineCollection({
         .string()
         .optional()
         .transform((val) => (val ? parseDate(val) : undefined)),
+      hideFromProduction: z.boolean().optional(),
     }),
 });
 

--- a/src/content/employees/daniel.md
+++ b/src/content/employees/daniel.md
@@ -1,6 +1,7 @@
 ---
 name: 'Daniel'
 image: './daniel-1-square.jpg'
+hideFromProduction: true
 ---
 
 Daniel er fullstackutvikleren som bryr seg om at teamet og sjappa jobber fornuftig og effektivt. I tillegg til sine sosiotekniske fakter er Daniel en råtass i Java, og har jobbet mye med dataintensive løsninger. Han har en BSc i Anvendt datateknologi fra Oslo Met, og er en ordentlig nysgjerrigper på nye teknologier. l

--- a/src/content/projects/cognite/index.mdx
+++ b/src/content/projects/cognite/index.mdx
@@ -5,6 +5,7 @@ image: './cognite.svg'
 fullLogo: './cognite-dark.svg'
 kyndLogo: './cognite-kynd-dark.svg'
 description: 'Daniel i Kynd har jobbet med data engineering og AI i Cognite'
+hideFromProduction: true
 ---
 
 import PageSection from '@/components/PageSection.astro';

--- a/src/content/projects/ssb/index.mdx
+++ b/src/content/projects/ssb/index.mdx
@@ -6,6 +6,7 @@ fullLogo: './ssb-dark.svg'
 kyndLogo: './ssb-kynd-dark.svg'
 description: 'Daniel hjalp SSB med å digitalisere undersøkelsen som kartlegger den norske befolkningens forbruksmønster. '
 startDate: '2024-03'
+hideFromProduction: true
 ---
 
 import PageSection from '@/components/PageSection.astro';

--- a/src/pages/folka/[id].astro
+++ b/src/pages/folka/[id].astro
@@ -3,9 +3,10 @@ import { getCollection, render, type CollectionEntry } from 'astro:content';
 import EmployeeGrid from '@/components/EmployeeGrid.astro';
 import Image from '@/components/Image.astro';
 import Layout from '@/layouts/Base.astro';
+import { filterForProduction } from '@/utils/contentVisibility';
 
 export async function getStaticPaths() {
-  const employees = await getCollection('employees');
+  const employees = filterForProduction(await getCollection('employees'));
   return employees.map((employee) => ({
     params: { id: employee.id },
     props: employee,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,6 @@
 ---
-import teamImage from '@/assets/felles-1.jpg';
 import ContactUs from '@/components/ContactUs.astro';
 import HeroSection from '@/components/HeroSection.astro';
-import Image from '@/components/Image.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import Layout from '@/layouts/Base.astro';
@@ -19,17 +17,12 @@ import Layout from '@/layouts/Base.astro';
   <PageSection heading="Team" subheading="Vi skaper kynd sammen">
     <Prose align="right">
       <p>
-        Kynd ble stiftet i 2024 av tre amigos - Daniel, Frederik og Axel - som har gått sammen om å
-        lage en transparent, spennende og nytenkende arbeidsplass. Vi er et konsulentbyrå innen
-        fullstack softwareutvikling, organisasjonsdesign og smidig teknologiledelse.
+        Kynd ble stiftet i 2024 med ambisjon om å lage en transparent, spennende og nytenkende
+        arbeidsplass. Vi er et konsulentbyrå innen fullstack softwareutvikling, organisasjonsdesign
+        og smidig teknologiledelse.
       </p>
       <!-- <Link href="/folka" variant="dark-primary">Les mer</Link> -->
     </Prose>
-    <Image
-      src={teamImage}
-      alt="Tre amigos - Axel, Daniel og Frederik - står foran en gul vegg med armene i kryss og ser ganske så fornøyde ut"
-      layout="full-width"
-    />
   </PageSection>
 
   <!-- <PageSection heading="Tjenester" subheading="Hva kan vi hjelpe deg med?">

--- a/src/pages/om-oss.astro
+++ b/src/pages/om-oss.astro
@@ -1,7 +1,5 @@
 ---
-import omOssImage from '@/assets/felles-3.jpg';
 import HeroSection from '@/components/HeroSection.astro';
-import Image from '@/components/Image.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import Layout from '@/layouts/Base.astro';
@@ -10,7 +8,7 @@ import Layout from '@/layouts/Base.astro';
 <Layout title="Om oss" description="Om oss">
   <HeroSection
     title="Om oss"
-    preamble="Kynd ble stiftet i 2024 av tre amigos - Daniel, Frederik og Axel – som har gått sammen om å lage en transparent, spennende og nytenkende arbeidsplass."
+    preamble="Kynd ble stiftet i 2024 med ambisjon om å lage en transparent, spennende og nytenkende arbeidsplass."
   />
   <Prose align="right">
     <p>
@@ -18,11 +16,6 @@ import Layout from '@/layouts/Base.astro';
       produkt-, team og endringsledelse.
     </p>
   </Prose>
-  <Image
-    src={omOssImage}
-    alt="Tre amigos - Axel, Daniel og Frederik - står foran en gul vegg med armene i kryss og ser ganske så fornøyde ut"
-    layout="full-width"
-  />
   <PageSection heading="Fundamentet">
     <Prose align="left">
       <p>

--- a/src/pages/prosjekter/[id].astro
+++ b/src/pages/prosjekter/[id].astro
@@ -3,9 +3,10 @@ import { getCollection, render, type CollectionEntry } from 'astro:content';
 import HeroSection from '@/components/HeroSection.astro';
 import Layout from '@/layouts/Base.astro';
 import { calculateDuration } from '@/utils/dateHelpers';
+import { filterForProduction } from '@/utils/contentVisibility';
 
 export async function getStaticPaths() {
-  const projects = await getCollection('projects');
+  const projects = filterForProduction(await getCollection('projects'));
   return projects.map((project) => ({
     params: { id: project.id },
     props: project,

--- a/src/utils/contentVisibility.ts
+++ b/src/utils/contentVisibility.ts
@@ -1,0 +1,18 @@
+type HideableEntry = {
+  data: {
+    hideFromProduction?: boolean | undefined;
+  };
+};
+
+export const isProductionBuild = import.meta.env.PROD;
+
+export const isVisibleInProduction = <T extends HideableEntry>(entry: T): boolean => {
+  if (!isProductionBuild) {
+    return true;
+  }
+
+  return entry.data.hideFromProduction !== true;
+};
+
+export const filterForProduction = <T extends HideableEntry>(entries: T[]): T[] =>
+  entries.filter(isVisibleInProduction);

--- a/src/utils/projectHelpers.ts
+++ b/src/utils/projectHelpers.ts
@@ -1,9 +1,10 @@
 import { getCollection } from 'astro:content';
 import { addDurationToProject } from './dateHelpers';
+import { filterForProduction } from './contentVisibility';
 
 // Get all projects with duration calculated
 export const getProjectsWithDuration = async () => {
-  const projects = await getCollection('projects');
+  const projects = filterForProduction(await getCollection('projects'));
   return projects.map((project) => ({
     ...project,
     data: addDurationToProject(project.data),
@@ -12,7 +13,7 @@ export const getProjectsWithDuration = async () => {
 
 // Get a single project with duration calculated
 export const getProjectWithDuration = async (id: string) => {
-  const projects = await getCollection('projects');
+  const projects = filterForProduction(await getCollection('projects'));
   const project = projects.find((p) => p.id === id);
   if (!project) return null;
 


### PR DESCRIPTION
## Summary
- Adds a production visibility flag for content entries and filters hidden employees/projects from generated routes and public grids.
- Marks Daniel, SSB, and Cognite content entries hidden from production while keeping the source references in the repo.
- Removes rendered trio copy and trio photos from the homepage and about page.

## Test plan
- `pnpm check`
- `pnpm build`
- Searched `dist/` for `Daniel`, `daniel`, `tre amigos`, `felles-1`, `felles-3`, and `daniel-1-square`; no matches found.
- Verified generated output has no `/folka/daniel`, `/prosjekter/ssb`, or `/prosjekter/cognite` route directories.
- Verified sitemap excludes the hidden routes.


Made with [Cursor](https://cursor.com)