### PR TITLE
Add tjenester page and homepage service links

### DIFF
--- a/src/components/ContactUs.astro
+++ b/src/components/ContactUs.astro
@@ -8,7 +8,8 @@ import TextArea from './TextArea.astro';
 <div class="wrapper">
   <div>
     <h3>Bring on the hustle</h3>
-    <p>Send oss en melding a, den går rett i Slack-en vår</p>
+    <p>Nysgjerrig på samarbeid, enten som kunde eller kompanjong?</p>
+    <p>Hit us up! Meldinga går rett i Slack-en vår</p>
     <form class="contact-form">
       <Input id="contact-us-name" name="name" label="Navn" placeholder="Navn" />
       <Input

--- a/src/components/ContactUs.astro
+++ b/src/components/ContactUs.astro
@@ -8,8 +8,10 @@ import TextArea from './TextArea.astro';
 <div class="wrapper">
   <div>
     <h3>Bring on the hustle</h3>
-    <p>Nysgjerrig på samarbeid, enten som kunde eller kompanjong?</p>
-    <p>Hit us up! Meldinga går rett i Slack-en vår</p>
+    <p>
+      Nysgjerrig på samarbeid, enten som kunde eller kompanjong?<br />
+      Hit us up! Meldinga går rett i Slack-en vår.
+    </p>
     <form class="contact-form">
       <Input id="contact-us-name" name="name" label="Navn" placeholder="Navn" />
       <Input

--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -73,7 +73,7 @@ const linkVariant = variantMap[variant];
   }
 
   .heading-container {
-    max-width: 50%;
+    max-width: 75%;
     z-index: 1;
   }
 

--- a/src/components/OffsetProseSection.astro
+++ b/src/components/OffsetProseSection.astro
@@ -1,0 +1,174 @@
+---
+export type Props = {
+  slug?: string;
+  heading: string;
+  /** When true (default), the heading gets the green accent background. */
+  accentHeading?: boolean;
+};
+
+const { slug, heading, accentHeading = true } = Astro.props;
+---
+
+<section id={slug}>
+  <div class="intro">
+    <h2 class:list={{ accent: accentHeading }}>{heading}</h2>
+    <slot name="intro" />
+  </div>
+  <div class="body-row">
+    <div class="body">
+      <slot />
+    </div>
+  </div>
+</section>
+
+<style>
+  section {
+    display: grid;
+    gap: 2.5rem;
+  }
+
+  .intro {
+    display: grid;
+    gap: 2rem;
+    max-width: 31.125rem;
+  }
+
+  h2 {
+    justify-self: start;
+    font-size: var(--fs-heading-m);
+  }
+
+  h2.accent {
+    background-color: var(--color-accent);
+    padding: 0.5rem;
+  }
+
+  .intro,
+  .body {
+    font-size: var(--fs-body-l);
+    font-weight: var(--font-weight-normal);
+  }
+
+  .body-row {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .body {
+    width: 100%;
+    max-width: 54.375rem;
+  }
+
+  .intro :global(p:not(:last-child)),
+  .body :global(p:not(:last-child)) {
+    margin-block-end: 1em;
+  }
+
+  .intro :global(h3),
+  .intro :global(h4),
+  .body :global(h3),
+  .body :global(h4) {
+    font-weight: bold;
+    margin-block-end: 0.75em;
+  }
+
+  .intro :global(code),
+  .body :global(code) {
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.8em;
+    background-color: var(--color-light-gray);
+    padding: 0.125em 0.25em;
+    border-radius: 0.25em;
+    color: var(--color-primary);
+  }
+
+  .intro :global(ul),
+  .intro :global(ol),
+  .body :global(ul),
+  .body :global(ol) {
+    list-style: revert;
+    padding-inline-start: 1em;
+  }
+
+  .intro :global(li),
+  .body :global(li) {
+    margin-block: 0.5em;
+  }
+
+  .intro :global(a),
+  .body :global(a) {
+    word-break: break-word;
+    color: var(--color-text);
+    text-decoration: underline;
+    text-decoration-color: var(--color-gray);
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 0.1em;
+    transition: all var(--animation-duration) ease;
+  }
+
+  .intro :global(a:hover),
+  .body :global(a:hover) {
+    color: var(--color-primary);
+    text-decoration-color: var(--color-primary);
+    text-decoration-thickness: 0.15em;
+  }
+
+  .intro :global(a:focus-visible),
+  .body :global(a:focus-visible) {
+    outline: 0.125rem solid var(--color-focus);
+    outline-offset: 0.125rem;
+    border-radius: 0.125rem;
+  }
+
+  .intro :global(a[href^='http']),
+  .body :global(a[href^='http']) {
+    position: relative;
+  }
+
+  .intro :global(a[href^='http'])::after,
+  .body :global(a[href^='http'])::after {
+    content: '';
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    margin-inline-start: 0.25em;
+    opacity: 0.7;
+    transition: opacity var(--animation-duration) ease;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    vertical-align: baseline;
+  }
+
+  .intro :global(a[href^='http']:hover)::after,
+  .body :global(a[href^='http']:hover)::after {
+    opacity: 1;
+  }
+
+  .intro :global(a[href^='#']:hover),
+  .body :global(a[href^='#']:hover) {
+    color: var(--color-accent);
+    text-decoration-color: var(--color-accent);
+  }
+
+  .intro :global(i),
+  .intro :global(em),
+  .body :global(i),
+  .body :global(em) {
+    font-style: italic;
+  }
+
+  .intro :global(b),
+  .intro :global(strong),
+  .body :global(b),
+  .body :global(strong) {
+    font-weight: var(--font-weight-semibold);
+  }
+
+  @media (--md) {
+    section {
+      gap: 4rem;
+    }
+  }
+</style>

--- a/src/components/PageSection.astro
+++ b/src/components/PageSection.astro
@@ -1,16 +1,18 @@
 ---
 export type Props = {
-  id?: string;
+  slug?: string;
   heading: string;
   subheading?: string;
+  /** When true (default), the heading gets the green accent background. */
+  accentHeading?: boolean;
 };
 
-const { id, heading, subheading } = Astro.props;
+const { slug, heading, subheading, accentHeading = true } = Astro.props;
 ---
 
-<section id={id}>
+<section id={slug}>
   <div class="heading-container">
-    <h2>{heading}</h2>
+    <h2 class:list={{ accent: accentHeading }}>{heading}</h2>
     <div class="subheading">{subheading}</div>
   </div>
   <slot />
@@ -41,6 +43,9 @@ const { id, heading, subheading } = Astro.props;
 
   h2 {
     font-size: var(--fs-heading-m);
+  }
+
+  h2.accent {
     background-color: var(--color-accent);
     padding: 0.5rem;
   }

--- a/src/components/handbook/HandbookSection.astro
+++ b/src/components/handbook/HandbookSection.astro
@@ -9,6 +9,6 @@ const entry = Astro.props;
 const { Content } = await render(entry);
 ---
 
-<PageSection heading={entry.data.title} id={entry.id}>
+<PageSection heading={entry.data.title} slug={entry.id}>
   <Content />
 </PageSection>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
 import ContactUs from '@/components/ContactUs.astro';
 import HeroSection from '@/components/HeroSection.astro';
+import OffsetProseSection from '@/components/OffsetProseSection.astro';
 import PageSection from '@/components/PageSection.astro';
-import Prose from '@/components/Prose.astro';
 import Layout from '@/layouts/Base.astro';
 import LinkCard from '@/components/LinkCard.astro';
 // import Link from '@/components/Link.astro';
@@ -14,32 +14,26 @@ import LinkCard from '@/components/LinkCard.astro';
     preamble="En gjeng kompetente folk som bygger et annerledes konsulentbyrå sammen."
     image="/patterns/pattern-0.svg"
   />
-  <PageSection heading="Team" subheading="Vi skaper kynd sammen">
-    <Prose align="right">
-      <p>
-        Kynd ble stiftet i 2024 med ambisjon om å lage en transparent, spennende og nytenkende
-        arbeidsplass. Vi er et konsulentbyrå innen fullstack softwareutvikling, organisasjonsdesign
-        og smidig teknologiledelse.
-      </p>
-    </Prose>
-  </PageSection>
+  <OffsetProseSection heading="Team is everything">
+    <p>
+      Kynd ble stiftet i 2024 med ambisjon om å lage en transparent, spennende og nytenkende
+      arbeidsplass. Vi er et teknologi- og produktbyrå som hjelper organisasjoner med å løse
+      vanskelige problemer, bygge bedre team og få bedre produkter, raskere.
+    </p>
+  </OffsetProseSection>
 
-  <PageSection heading="Tjenester" subheading="Hva kan vi hjelpe deg med?">
+  <PageSection heading="Tjenester" accentHeading={false}>
     <div class="services-grid">
       <LinkCard
         variant="default"
         heading="Partnerskap for problemløsing"
-        href="/tjenester#partnerskap-for-problemlosing"
+        href="/tjenester#partnerskap"
       />
-      <LinkCard
-        variant="green"
-        heading="Kompetanse rett i ditt team"
-        href="/tjenester#kompetanse-rett-i-ditt-team"
-      />
+      <LinkCard variant="green" heading="Kapasitet og kompetanse" href="/tjenester#kompetanse" />
       <LinkCard
         variant="black"
         heading="Produktfilosofi og sosioteknisk design"
-        href="/tjenester#produktfilosofi-og-sosioteknisk-design"
+        href="/tjenester#produktfilosofi"
       />
     </div>
   </PageSection>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import HeroSection from '@/components/HeroSection.astro';
 import PageSection from '@/components/PageSection.astro';
 import Prose from '@/components/Prose.astro';
 import Layout from '@/layouts/Base.astro';
-// import LinkCard from '@/components/LinkCard.astro';
+import LinkCard from '@/components/LinkCard.astro';
 // import Link from '@/components/Link.astro';
 ---
 
@@ -21,21 +21,28 @@ import Layout from '@/layouts/Base.astro';
         arbeidsplass. Vi er et konsulentbyrå innen fullstack softwareutvikling, organisasjonsdesign
         og smidig teknologiledelse.
       </p>
-      <!-- <Link href="/folka" variant="dark-primary">Les mer</Link> -->
     </Prose>
   </PageSection>
 
-  <!-- <PageSection heading="Tjenester" subheading="Hva kan vi hjelpe deg med?">
+  <PageSection heading="Tjenester" subheading="Hva kan vi hjelpe deg med?">
     <div class="services-grid">
       <LinkCard
         variant="default"
-        heading="Fullstack Softwareutvikling"
-        href="/tjenester/fullstack"
+        heading="Partnerskap for problemløsing"
+        href="/tjenester#partnerskap-for-problemlosing"
       />
-      <LinkCard variant="green" heading="Design UX/UI" href="/tjenester/design" />
-      <LinkCard variant="black" heading="Digital Strategi" href="/tjenester/strategi" />
+      <LinkCard
+        variant="green"
+        heading="Kompetanse rett i ditt team"
+        href="/tjenester#kompetanse-rett-i-ditt-team"
+      />
+      <LinkCard
+        variant="black"
+        heading="Produktfilosofi og sosioteknisk design"
+        href="/tjenester#produktfilosofi-og-sosioteknisk-design"
+      />
     </div>
-  </PageSection> -->
+  </PageSection>
   <PageSection
     heading="Kontakt oss"
     subheading="Nysgjerrig på samarbeid, enten som medeier eller kunde? Hit us up!"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,12 +43,11 @@ import LinkCard from '@/components/LinkCard.astro';
       />
     </div>
   </PageSection>
-  <PageSection
+  <!-- <PageSection
     heading="Kontakt oss"
-    subheading="Nysgjerrig på samarbeid, enten som medeier eller kunde? Hit us up!"
-  >
-    <ContactUs />
-  </PageSection>
+    subheading="Nysgjerrig på samarbeid, enten som kunde eller kompanjong? Hit us up!"
+  > -->
+  <ContactUs />
 </Layout>
 
 <style>

--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -1,0 +1,83 @@
+---
+import ContactUs from '@/components/ContactUs.astro';
+import HeroSection from '@/components/HeroSection.astro';
+import PageSection from '@/components/PageSection.astro';
+import Prose from '@/components/Prose.astro';
+import Layout from '@/layouts/Base.astro';
+---
+
+<Layout
+  title="Tjenester"
+  description="Kynd hjelper med partnerskap for problemløsing, kompetanse i team og produktfilosofi."
+>
+  <HeroSection
+    title="Tjenester"
+    preamble="Vi hjelper teknologi- og produktmiljøer med å løse vanskelige problemer, bygge bedre team og ta klokere produktvalg."
+    image="/patterns/pattern-0.svg"
+  />
+
+  <PageSection
+    id="partnerskap-for-problemlosing"
+    heading="Partnerskap for problemløsing"
+    subheading="For deg som trenger mer enn ekstra hender."
+  >
+    <Prose align="left">
+      <p>
+        Vi går inn som en aktiv sparringspartner når problemet er uklart, tverrfaglig eller
+        vanskelig å få tak på. Det kan handle om å forstå brukerbehov, rydde i tekniske og
+        organisatoriske avhengigheter, eller finne en vei fra idé til noe som faktisk kan testes.
+      </p>
+    </Prose>
+    <Prose align="right">
+      <p>
+        Målet er ikke å selge inn en ferdig metode, men å jobbe tett med folkene deres og finne ut
+        hva som gir mest verdi. Vi bidrar med produktledelse, teknologiforståelse, fasilitering og
+        praktisk gjennomføring.
+      </p>
+    </Prose>
+  </PageSection>
+
+  <PageSection
+    id="kompetanse-rett-i-ditt-team"
+    heading="Kompetanse rett i ditt team"
+    subheading="Når teamet trenger erfaren kapasitet som kan bidra fra innsiden."
+  >
+    <Prose align="left">
+      <p>
+        Vi kan forsterke eksisterende team med erfarne utviklere, teknologer og folk som er vant til
+        å ta ansvar for både kode, prosess og samarbeid. Vi trives best tett på produktet, brukerne
+        og beslutningene.
+      </p>
+    </Prose>
+    <Prose align="right">
+      <p>
+        Det betyr at vi ikke bare leverer oppgaver, men også bidrar til bedre flyt, tydeligere
+        prioriteringer og mer læring i teamet. Kompetansen vår dekker fullstack utvikling,
+        plattform, smidig teknologiledelse og teamutvikling.
+      </p>
+    </Prose>
+  </PageSection>
+
+  <PageSection
+    id="produktfilosofi-og-sosioteknisk-design"
+    heading="Produktfilosofi og sosioteknisk design"
+    subheading="For organisasjoner som vil bygge systemer, team og beslutninger som henger sammen."
+  >
+    <Prose align="left">
+      <p>
+        Gode digitale produkter blir ikke bare til gjennom god kode. De formes også av hvordan team
+        er satt sammen, hvordan ansvar fordeles, hvilke mål som styrer arbeidet og hvor raskt man
+        lærer av virkeligheten.
+      </p>
+    </Prose>
+    <Prose align="right">
+      <p>
+        Vi hjelper med å designe produkt- og teknologiarbeid som tar hele systemet på alvor: folk,
+        organisering, arkitektur og brukerbehov. Det kan være gjennom rådgivning, workshops,
+        produktstrategi eller praktisk endringsarbeid sammen med teamene deres.
+      </p>
+    </Prose>
+  </PageSection>
+
+  <ContactUs />
+</Layout>

--- a/src/pages/tjenester.astro
+++ b/src/pages/tjenester.astro
@@ -17,30 +17,32 @@ import Layout from '@/layouts/Base.astro';
   />
 
   <PageSection
-    id="partnerskap-for-problemlosing"
+    slug="partnerskap"
     heading="Partnerskap for problemløsing"
-    subheading="For deg som trenger mer enn ekstra hender."
+    subheading="Når du trenger mer enn ekstra hender."
   >
     <Prose align="left">
       <p>
-        Vi går inn som en aktiv sparringspartner når problemet er uklart, tverrfaglig eller
-        vanskelig å få tak på. Det kan handle om å forstå brukerbehov, rydde i tekniske og
-        organisatoriske avhengigheter, eller finne en vei fra idé til noe som faktisk kan testes.
+        Digitale løsninger er svaret på mange utfordringer. Gode digitale produkter trenger
+        kjærlighet, ikke bare når de blir etablert, men gjennom hele livssyklusen. For å sikre at
+        produkter fortsetter å levere verdi, er det ikke alltid at en organisasjon skal eie
+        produktet alene.
       </p>
     </Prose>
     <Prose align="right">
       <p>
-        Målet er ikke å selge inn en ferdig metode, men å jobbe tett med folkene deres og finne ut
-        hva som gir mest verdi. Vi bidrar med produktledelse, teknologiforståelse, fasilitering og
-        praktisk gjennomføring.
+        Derfor utvikler og drifter vi digitale løsninger gjennom partnerskap, ikke bare vanlig
+        «kunde-leverandør»-forhold. Vi deler risiko og oppside, og produktet ditt vil fortsette å
+        utvikle seg ettersom behovene endres. Som de jo til stadighet gjør, til alle
+        IT-fossefallsprosjekters store frustrasjon.
       </p>
     </Prose>
   </PageSection>
 
   <PageSection
-    id="kompetanse-rett-i-ditt-team"
-    heading="Kompetanse rett i ditt team"
-    subheading="Når teamet trenger erfaren kapasitet som kan bidra fra innsiden."
+    slug="kompetanse"
+    heading="Kompetanse og kapasitet"
+    subheading="Når du trenger ekstra hender. "
   >
     <Prose align="left">
       <p>
@@ -59,22 +61,23 @@ import Layout from '@/layouts/Base.astro';
   </PageSection>
 
   <PageSection
-    id="produktfilosofi-og-sosioteknisk-design"
+    slug="produktfilosofi"
     heading="Produktfilosofi og sosioteknisk design"
-    subheading="For organisasjoner som vil bygge systemer, team og beslutninger som henger sammen."
+    subheading="«Alle» snakker om produktorganisering. Få snakker om produktfilosofi. "
   >
     <Prose align="left">
       <p>
-        Gode digitale produkter blir ikke bare til gjennom god kode. De formes også av hvordan team
-        er satt sammen, hvordan ansvar fordeles, hvilke mål som styrer arbeidet og hvor raskt man
-        lærer av virkeligheten.
+        Skal du bygge gode produkter, trenger du en organisasjon som tilrettelegger for god
+        produktutvikling. «Fart og flyt» oppstår ikke av seg selv, og litt omorganisering hjelper
+        ikke hvis ikke de sosiotekniske aspektene tas på alvor.
       </p>
     </Prose>
     <Prose align="right">
       <p>
-        Vi hjelper med å designe produkt- og teknologiarbeid som tar hele systemet på alvor: folk,
-        organisering, arkitektur og brukerbehov. Det kan være gjennom rådgivning, workshops,
-        produktstrategi eller praktisk endringsarbeid sammen med teamene deres.
+        Vi hjelper med innsikt og analyse av organisasjon og kultur, kursing, opplæring og
+        hands-on-arbeid på strategisk og operativt nivå. Siden sosioteknisk og kulturell dynamikk i
+        organisasjoner bør/må oppleves, leverer vi helst praktisk produktledelse som en del av
+        arbeidet.
       </p>
     </Prose>
   </PageSection>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11,7 +11,7 @@
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: 1rem;
+  scroll-padding-top: calc(var(--size-header) + 1rem);
 }
 
 body {


### PR DESCRIPTION
## Summary
- Add `/tjenester` with three anchored service areas: partnerskap for problemløsing, kompetanse rett i ditt team, and produktfilosofi og sosioteknisk design
- Enable the homepage services section and link each card to the matching section on `/tjenester`
- Move contact intro copy into `ContactUs` and simplify the homepage contact layout

## Test plan
- [ ] Open `/` and verify the three service cards link to the correct sections on `/tjenester`
- [ ] Review `/tjenester` copy and section anchors in the browser
- [ ] Confirm the contact form still renders and submits on both `/` and `/tjenester`

Made with [Cursor](https://cursor.com)