### PR TITLE
Add tjenester page and refresh homepage services section

### DIFF
--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -157,7 +157,9 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
 
   function getVisibleClients(slots: HTMLAnchorElement[]): Set<string> {
     return new Set(
-      slots.map((slot) => slot.dataset.clientKey).filter((client): client is string => Boolean(client)),
+      slots
+        .map((slot) => slot.dataset.clientKey)
+        .filter((client): client is string => Boolean(client)),
     );
   }
 
@@ -251,7 +253,9 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
     let queueIndex = 0;
 
     const takeNext = (visibleClients: Set<string>): LogoItem => {
-      for (let attempt = 0; attempt < queue.length; attempt += 1) {
+      let attempts = 0;
+      while (attempts < queue.length) {
+        attempts += 1;
         if (queueIndex >= queue.length) {
           queue = shuffle(allLogos);
           queueIndex = 0;

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -1,6 +1,8 @@
 ---
 export type LogoItem = {
   id: string;
+  /** Stable client identity used to avoid duplicate clients in one view. */
+  client: string;
   href: string;
   src: string;
   alt: string;
@@ -27,13 +29,34 @@ function shuffle<T>(items: T[]): T[] {
   return shuffled;
 }
 
-const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice(0, visibleCount);
+function pickInitialLogos(items: LogoItem[], count: number): LogoItem[] {
+  const picked: LogoItem[] = [];
+  const visibleClients = new Set<string>();
+
+  for (const logo of shuffle(items)) {
+    if (visibleClients.has(logo.client)) continue;
+
+    visibleClients.add(logo.client);
+    picked.push(logo);
+    if (picked.length >= count) break;
+  }
+
+  return picked;
+}
+
+const initialLogos = pickInitialLogos(logos, visibleCount);
 ---
 
 <div class="logo-band" data-logos={JSON.stringify(logos)} data-visible-count={visibleCount}>
   {
     initialLogos.map((logo) => (
-      <a href={logo.href} class="logo-slot" aria-label={logo.alt} data-logo-id={logo.id}>
+      <a
+        href={logo.href}
+        class="logo-slot"
+        aria-label={logo.alt}
+        data-logo-id={logo.id}
+        data-client-key={logo.client}
+      >
         <img
           src={logo.src}
           alt={logo.alt}
@@ -102,6 +125,7 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
 <script>
   type LogoItem = {
     id: string;
+    client: string;
     href: string;
     src: string;
     alt: string;
@@ -131,9 +155,9 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     }
   }
 
-  function getVisibleIds(slots: HTMLAnchorElement[]): Set<string> {
+  function getVisibleClients(slots: HTMLAnchorElement[]): Set<string> {
     return new Set(
-      slots.map((slot) => slot.dataset.logoId).filter((id): id is string => Boolean(id)),
+      slots.map((slot) => slot.dataset.clientKey).filter((client): client is string => Boolean(client)),
     );
   }
 
@@ -162,6 +186,7 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     slot.href = logo.href;
     slot.setAttribute('aria-label', logo.alt);
     slot.dataset.logoId = logo.id;
+    slot.dataset.clientKey = logo.client;
 
     const image = slot.querySelector('img');
     if (image) {
@@ -174,10 +199,8 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     let queue = shuffle(allLogos);
     let queueIndex = 0;
 
-    const takeNext = (visibleIds: Set<string>): LogoItem => {
-      const attempts = queue.length;
-
-      for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const takeNext = (visibleClients: Set<string>): LogoItem => {
+      for (let attempt = 0; attempt < queue.length; attempt += 1) {
         if (queueIndex >= queue.length) {
           queue = shuffle(allLogos);
           queueIndex = 0;
@@ -186,12 +209,17 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
         const candidate = queue[queueIndex];
         queueIndex += 1;
 
-        if (candidate && !visibleIds.has(candidate.id)) {
+        if (candidate && !visibleClients.has(candidate.client)) {
           return candidate;
         }
       }
 
-      const fallback = queue[queueIndex - 1] ?? allLogos[0];
+      queue = shuffle(allLogos);
+      queueIndex = 0;
+
+      const fallback = queue[queueIndex];
+      queueIndex += 1;
+
       if (!fallback) {
         throw new Error('ClientLogoBand requires at least one logo.');
       }
@@ -215,25 +243,26 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
       void preloadImage(logo.src);
     });
 
+    const uniqueClientCount = new Set(logos.map((logo) => logo.client)).size;
     const { takeNext } = createQueueState(logos);
     let slotIndex = 0;
 
     window.setInterval(() => {
       const activeSlots = getActiveSlots(slots);
       if (activeSlots.length === 0) return;
-      if (activeSlots.length >= logos.length) return;
+      if (activeSlots.length >= uniqueClientCount) return;
 
       const slot = activeSlots[slotIndex % activeSlots.length];
       if (!slot) return;
 
-      const visibleIds = getVisibleIds(activeSlots);
-      const currentId = slot.dataset.logoId;
+      const visibleClients = getVisibleClients(activeSlots);
+      const currentClient = slot.dataset.clientKey;
 
-      if (currentId) {
-        visibleIds.delete(currentId);
+      if (currentClient) {
+        visibleClients.delete(currentClient);
       }
 
-      const logo = takeNext(visibleIds);
+      const logo = takeNext(visibleClients);
 
       void preloadImage(logo.src)
         .then(() => {

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -195,6 +195,26 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
     }
   }
 
+  function dedupeActiveSlots(
+    activeSlots: HTMLAnchorElement[],
+    takeNext: (visibleClients: Set<string>) => LogoItem,
+  ) {
+    const occupiedClients = new Set<string>();
+
+    for (const slot of activeSlots) {
+      const client = slot.dataset.clientKey;
+
+      if (client && !occupiedClients.has(client)) {
+        occupiedClients.add(client);
+        continue;
+      }
+
+      const logo = takeNext(occupiedClients);
+      applyLogo(slot, logo);
+      occupiedClients.add(logo.client);
+    }
+  }
+
   function createQueueState(allLogos: LogoItem[]) {
     let queue = shuffle(allLogos);
     let queueIndex = 0;
@@ -246,8 +266,25 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
     const uniqueClientCount = new Set(logos.map((logo) => logo.client)).size;
     const { takeNext } = createQueueState(logos);
     let slotIndex = 0;
+    let activeSlotCount = getActiveSlots(slots).length;
+
+    const syncActiveSlotCount = () => {
+      const nextActiveSlotCount = getActiveSlots(slots).length;
+      if (nextActiveSlotCount === activeSlotCount) return;
+
+      activeSlotCount = nextActiveSlotCount;
+      dedupeActiveSlots(getActiveSlots(slots), takeNext);
+      slotIndex = 0;
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      syncActiveSlotCount();
+    });
+    resizeObserver.observe(band);
 
     window.setInterval(() => {
+      syncActiveSlotCount();
+
       const activeSlots = getActiveSlots(slots);
       if (activeSlots.length === 0) return;
       if (activeSlots.length >= uniqueClientCount) return;

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -1,0 +1,212 @@
+---
+export type LogoItem = {
+  id: string;
+  href: string;
+  src: string;
+  alt: string;
+};
+
+export type Props = {
+  logos: LogoItem[];
+  /** Number of logo slots rendered and rotated. */
+  visibleCount?: number;
+};
+
+const { logos, visibleCount = 5 } = Astro.props;
+
+function shuffle<T>(items: T[]): T[] {
+  const shuffled = [...items];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    const current = shuffled[index];
+    const swap = shuffled[swapIndex];
+    if (current === undefined || swap === undefined) continue;
+    shuffled[index] = swap;
+    shuffled[swapIndex] = current;
+  }
+  return shuffled;
+}
+
+const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice(0, visibleCount);
+---
+
+<div class="logo-band" data-logos={JSON.stringify(logos)} data-visible-count={visibleCount}>
+  {
+    initialLogos.map((logo) => (
+      <a href={logo.href} class="logo-slot" aria-label={logo.alt} data-logo-id={logo.id}>
+        <img
+          src={logo.src}
+          alt={logo.alt}
+          width="120"
+          height="48"
+          loading="lazy"
+          decoding="async"
+        />
+      </a>
+    ))
+  }
+</div>
+
+<style>
+  .logo-band {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem 2rem;
+    align-items: center;
+    width: 100%;
+
+    @media (--md) {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 2rem;
+    }
+  }
+
+  .logo-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 3rem;
+    padding: 0.5rem;
+    text-decoration: none;
+    transition: opacity var(--animation-duration) ease;
+  }
+
+  .logo-slot:is(:hover, :focus-visible) {
+    opacity: 0.75;
+  }
+
+  .logo-slot img {
+    display: block;
+    width: auto;
+    max-width: 100%;
+    height: auto;
+    max-height: 2rem;
+    object-fit: contain;
+
+    @media (--md) {
+      max-height: 2.5rem;
+    }
+  }
+
+  .logo-slot.is-swapping img {
+    opacity: 0;
+  }
+</style>
+
+<script>
+  type LogoItem = {
+    id: string;
+    href: string;
+    src: string;
+    alt: string;
+  };
+
+  function shuffle<T>(items: T[]): T[] {
+    const shuffled = [...items];
+    for (let index = shuffled.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(Math.random() * (index + 1));
+      const current = shuffled[index];
+      const swap = shuffled[swapIndex];
+      if (current === undefined || swap === undefined) continue;
+      shuffled[index] = swap;
+      shuffled[swapIndex] = current;
+    }
+    return shuffled;
+  }
+
+  function parseLogos(raw: string | undefined): LogoItem[] {
+    if (!raw) return [];
+
+    try {
+      const parsed = JSON.parse(raw) as LogoItem[];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function getVisibleIds(slots: HTMLAnchorElement[]): Set<string> {
+    return new Set(
+      slots.map((slot) => slot.dataset.logoId).filter((id): id is string => Boolean(id)),
+    );
+  }
+
+  function createQueueState(allLogos: LogoItem[]) {
+    let queue = shuffle(allLogos);
+    let queueIndex = 0;
+
+    const takeNext = (visibleIds: Set<string>): LogoItem => {
+      const attempts = queue.length;
+
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (queueIndex >= queue.length) {
+          queue = shuffle(allLogos);
+          queueIndex = 0;
+        }
+
+        const candidate = queue[queueIndex];
+        queueIndex += 1;
+
+        if (candidate && !visibleIds.has(candidate.id)) {
+          return candidate;
+        }
+      }
+
+      const fallback = queue[queueIndex - 1] ?? allLogos[0];
+      if (!fallback) {
+        throw new Error('ClientLogoBand requires at least one logo.');
+      }
+
+      return fallback;
+    };
+
+    return { takeNext };
+  }
+
+  const bands = document.querySelectorAll<HTMLElement>('.logo-band');
+
+  bands.forEach((band) => {
+    const logos = parseLogos(band.dataset.logos);
+    const visibleCount = Number(band.dataset.visibleCount) || 5;
+
+    if (logos.length <= visibleCount) return;
+
+    const slots = [...band.querySelectorAll<HTMLAnchorElement>('.logo-slot')];
+    if (slots.length === 0) return;
+
+    const { takeNext } = createQueueState(logos);
+    let slotIndex = 0;
+
+    window.setInterval(() => {
+      const slot = slots[slotIndex];
+      if (!slot) return;
+
+      const visibleIds = getVisibleIds(slots);
+      const currentId = slot.dataset.logoId;
+
+      if (currentId) {
+        visibleIds.delete(currentId);
+      }
+
+      const logo = takeNext(visibleIds);
+
+      slot.classList.add('is-swapping');
+
+      window.setTimeout(() => {
+        slot.href = logo.href;
+        slot.setAttribute('aria-label', logo.alt);
+        slot.dataset.logoId = logo.id;
+
+        const image = slot.querySelector('img');
+        if (image) {
+          image.src = logo.src;
+          image.alt = logo.alt;
+        }
+
+        slot.classList.remove('is-swapping');
+      }, 150);
+
+      slotIndex = (slotIndex + 1) % slots.length;
+    }, 5000);
+  });
+</script>

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -182,6 +182,18 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
     return promise;
   }
 
+  const slotSwapGeneration = new WeakMap<HTMLAnchorElement, number>();
+
+  function beginLogoSwap(slot: HTMLAnchorElement): number {
+    const generation = (slotSwapGeneration.get(slot) ?? 0) + 1;
+    slotSwapGeneration.set(slot, generation);
+    return generation;
+  }
+
+  function isLatestLogoSwap(slot: HTMLAnchorElement, generation: number): boolean {
+    return slotSwapGeneration.get(slot) === generation;
+  }
+
   function applyLogo(slot: HTMLAnchorElement, logo: LogoItem) {
     slot.href = logo.href;
     slot.setAttribute('aria-label', logo.alt);
@@ -193,6 +205,25 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
       image.src = logo.src;
       image.alt = logo.alt;
     }
+  }
+
+  function applyLogoNow(slot: HTMLAnchorElement, logo: LogoItem) {
+    beginLogoSwap(slot);
+    applyLogo(slot, logo);
+  }
+
+  function applyLogoWhenReady(slot: HTMLAnchorElement, logo: LogoItem) {
+    const generation = beginLogoSwap(slot);
+
+    void preloadImage(logo.src)
+      .then(() => {
+        if (!isLatestLogoSwap(slot, generation)) return;
+        applyLogo(slot, logo);
+      })
+      .catch(() => {
+        if (!isLatestLogoSwap(slot, generation)) return;
+        applyLogo(slot, logo);
+      });
   }
 
   function dedupeActiveSlots(
@@ -210,7 +241,7 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
       }
 
       const logo = takeNext(occupiedClients);
-      applyLogo(slot, logo);
+      applyLogoNow(slot, logo);
       occupiedClients.add(logo.client);
     }
   }
@@ -300,14 +331,7 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
       }
 
       const logo = takeNext(occupiedClients);
-
-      void preloadImage(logo.src)
-        .then(() => {
-          applyLogo(slot, logo);
-        })
-        .catch(() => {
-          applyLogo(slot, logo);
-        });
+      applyLogoWhenReady(slot, logo);
 
       slotIndex = (slotIndex + 1) % activeSlots.length;
     }, 5000);

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -255,7 +255,7 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
       const slot = activeSlots[slotIndex % activeSlots.length];
       if (!slot) return;
 
-      const occupiedClients = getVisibleClients(slots);
+      const occupiedClients = getVisibleClients(activeSlots);
       const currentClient = slot.dataset.clientKey;
 
       if (currentClient) {

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -206,9 +206,7 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
 
   bands.forEach((band) => {
     const logos = parseLogos(band.dataset.logos);
-    const visibleCount = Number(band.dataset.visibleCount) || 5;
-
-    if (logos.length <= visibleCount) return;
+    if (logos.length <= 1) return;
 
     const slots = [...band.querySelectorAll<HTMLAnchorElement>('.logo-slot')];
     if (slots.length === 0) return;
@@ -223,6 +221,7 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     window.setInterval(() => {
       const activeSlots = getActiveSlots(slots);
       if (activeSlots.length === 0) return;
+      if (activeSlots.length >= logos.length) return;
 
       const slot = activeSlots[slotIndex % activeSlots.length];
       if (!slot) return;

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -255,14 +255,14 @@ const initialLogos = pickInitialLogos(logos, visibleCount);
       const slot = activeSlots[slotIndex % activeSlots.length];
       if (!slot) return;
 
-      const visibleClients = getVisibleClients(activeSlots);
+      const occupiedClients = getVisibleClients(slots);
       const currentClient = slot.dataset.clientKey;
 
       if (currentClient) {
-        visibleClients.delete(currentClient);
+        occupiedClients.delete(currentClient);
       }
 
-      const logo = takeNext(visibleClients);
+      const logo = takeNext(occupiedClients);
 
       void preloadImage(logo.src)
         .then(() => {

--- a/src/components/ClientLogoBand.astro
+++ b/src/components/ClientLogoBand.astro
@@ -71,6 +71,10 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     transition: opacity var(--animation-duration) ease;
   }
 
+  .logo-slot:nth-child(n + 4) {
+    display: none;
+  }
+
   .logo-slot:is(:hover, :focus-visible) {
     opacity: 0.75;
   }
@@ -88,8 +92,10 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     }
   }
 
-  .logo-slot.is-swapping img {
-    opacity: 0;
+  @media (--md) {
+    .logo-slot:nth-child(n + 4) {
+      display: flex;
+    }
   }
 </style>
 
@@ -129,6 +135,39 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     return new Set(
       slots.map((slot) => slot.dataset.logoId).filter((id): id is string => Boolean(id)),
     );
+  }
+
+  function getActiveSlots(slots: HTMLAnchorElement[]): HTMLAnchorElement[] {
+    return slots.filter((slot) => window.getComputedStyle(slot).display !== 'none');
+  }
+
+  const imageCache = new Map<string, Promise<void>>();
+
+  function preloadImage(src: string): Promise<void> {
+    const cached = imageCache.get(src);
+    if (cached) return cached;
+
+    const promise = new Promise<void>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error(`Failed to preload ${src}`));
+      image.src = src;
+    });
+
+    imageCache.set(src, promise);
+    return promise;
+  }
+
+  function applyLogo(slot: HTMLAnchorElement, logo: LogoItem) {
+    slot.href = logo.href;
+    slot.setAttribute('aria-label', logo.alt);
+    slot.dataset.logoId = logo.id;
+
+    const image = slot.querySelector('img');
+    if (image) {
+      image.src = logo.src;
+      image.alt = logo.alt;
+    }
   }
 
   function createQueueState(allLogos: LogoItem[]) {
@@ -174,14 +213,21 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
     const slots = [...band.querySelectorAll<HTMLAnchorElement>('.logo-slot')];
     if (slots.length === 0) return;
 
+    logos.forEach((logo) => {
+      void preloadImage(logo.src);
+    });
+
     const { takeNext } = createQueueState(logos);
     let slotIndex = 0;
 
     window.setInterval(() => {
-      const slot = slots[slotIndex];
+      const activeSlots = getActiveSlots(slots);
+      if (activeSlots.length === 0) return;
+
+      const slot = activeSlots[slotIndex % activeSlots.length];
       if (!slot) return;
 
-      const visibleIds = getVisibleIds(slots);
+      const visibleIds = getVisibleIds(activeSlots);
       const currentId = slot.dataset.logoId;
 
       if (currentId) {
@@ -190,23 +236,15 @@ const initialLogos = logos.length <= visibleCount ? logos : shuffle(logos).slice
 
       const logo = takeNext(visibleIds);
 
-      slot.classList.add('is-swapping');
+      void preloadImage(logo.src)
+        .then(() => {
+          applyLogo(slot, logo);
+        })
+        .catch(() => {
+          applyLogo(slot, logo);
+        });
 
-      window.setTimeout(() => {
-        slot.href = logo.href;
-        slot.setAttribute('aria-label', logo.alt);
-        slot.dataset.logoId = logo.id;
-
-        const image = slot.querySelector('img');
-        if (image) {
-          image.src = logo.src;
-          image.alt = logo.alt;
-        }
-
-        slot.classList.remove('is-swapping');
-      }, 150);
-
-      slotIndex = (slotIndex + 1) % slots.length;
+      slotIndex = (slotIndex + 1) % activeSlots.length;
     }, 5000);
   });
 </script>

--- a/src/components/PageSection.astro
+++ b/src/components/PageSection.astro
@@ -13,7 +13,7 @@ const { slug, heading, subheading, accentHeading = true } = Astro.props;
 <section id={slug}>
   <div class="heading-container">
     <h2 class:list={{ accent: accentHeading }}>{heading}</h2>
-    <div class="subheading">{subheading}</div>
+    {subheading && <div class="subheading">{subheading}</div>}
   </div>
   <slot />
 </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,21 @@
 ---
+import ClientLogoBand from '@/components/ClientLogoBand.astro';
 import ContactUs from '@/components/ContactUs.astro';
 import HeroSection from '@/components/HeroSection.astro';
 import OffsetProseSection from '@/components/OffsetProseSection.astro';
 import PageSection from '@/components/PageSection.astro';
 import Layout from '@/layouts/Base.astro';
 import LinkCard from '@/components/LinkCard.astro';
+import { getProjectsWithDuration } from '@/utils/projectHelpers';
 // import Link from '@/components/Link.astro';
+
+const projects = await getProjectsWithDuration();
+const clientLogos = projects.map((project) => ({
+  id: project.id,
+  href: `/prosjekter/${project.id}`,
+  src: project.data.fullLogo?.src ?? project.data.image.src,
+  alt: project.data.customer,
+}));
 ---
 
 <Layout>
@@ -22,7 +32,12 @@ import LinkCard from '@/components/LinkCard.astro';
     </p>
   </OffsetProseSection>
 
-  <PageSection heading="Tjenester" accentHeading={false}>
+  <PageSection
+    heading="Tjenester"
+    accentHeading={false}
+    subheading="Noen vi har hatt gleden av å hjelpe med digitalisering."
+  >
+    <ClientLogoBand logos={clientLogos} />
     <div class="services-grid">
       <LinkCard
         variant="default"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import { getProjectsWithDuration } from '@/utils/projectHelpers';
 const projects = await getProjectsWithDuration();
 const clientLogos = projects.map((project) => ({
   id: project.id,
+  client: project.data.customer,
   href: `/prosjekter/${project.id}`,
   src: project.data.fullLogo?.src ?? project.data.image.src,
   alt: project.data.customer,


### PR DESCRIPTION
## Summary
- Add a dedicated `/tjenester` page with three anchored service areas: partnerskap, kompetanse, and produktfilosofi.
- Refresh the homepage with an `OffsetProseSection` intro, enabled services cards linking to `/tjenester`, and a rotating client logo band sourced from project content.
- Improve shared section/layout behavior with optional accent headings, conditional subheadings, and anchor scroll offset below the sticky header.

## Test plan
- [ ] Open `/` and verify the Team section, Tjenester subheading, logo band rotation, and service card links.
- [ ] Confirm logo band shows 3 logos on mobile and 5 on desktop, with smooth swaps and links to `/prosjekter/{id}`.
- [ ] Open `/tjenester` and verify hero copy, three sections, anchor navigation, and contact block.
- [ ] Check contact section copy on homepage and tjenester page.
- [ ] Run `pnpm astro:check`.


Made with [Cursor](https://cursor.com)