### PR TITLE
Fix handbook prose rendering consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-astro": "^1.7.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "postcss-custom-media": "^12.0.1",
+    "postcss-nesting": "^14.0.0",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       postcss-custom-media:
         specifier: ^12.0.1
         version: 12.0.1(postcss@8.5.15)
+      postcss-nesting:
+        specifier: ^14.0.0
+        version: 14.0.0(postcss@8.5.15)
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -197,6 +200,18 @@ packages:
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.4
+
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
@@ -3816,6 +3831,12 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
+  postcss-nesting@14.0.0:
+    resolution: {integrity: sha512-YGFOfVrjxYfeGTS5XctP1WCI5hu8Lr9SmntjfRC+iX5hCihEO+QZl9Ra+pkjqkgoVdDKvb2JccpElcowhZtzpw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
@@ -5062,6 +5083,14 @@ snapshots:
   '@csstools/postcss-global-data@4.0.0(postcss@8.5.15)':
     dependencies:
       postcss: 8.5.15
+
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.4)':
+    dependencies:
+      postcss-selector-parser: 7.1.4
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.4)':
+    dependencies:
+      postcss-selector-parser: 7.1.4
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -9314,6 +9343,13 @@ snapshots:
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       postcss: 8.5.15
+
+  postcss-nesting@14.0.0(postcss@8.5.15):
+    dependencies:
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.4)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.4)
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
 
   postcss-selector-parser@7.1.4:
     dependencies:

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,5 @@
 import postcssGlobalData from '@csstools/postcss-global-data';
+import postcssNesting from 'postcss-nesting';
 import postcssCustomMedia from 'postcss-custom-media';
 
 export default {
@@ -6,6 +7,7 @@ export default {
     postcssGlobalData({
       files: ['./src/styles/variables.css'],
     }),
+    postcssNesting(),
     postcssCustomMedia(),
   ],
 };

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -20,114 +20,116 @@ const rightMargin = align === 'right' ? '0' : 'auto';
     font-weight: var(--font-weight-normal);
     margin-inline-start: var(--leftMargin);
     margin-inline-end: var(--rightMargin);
+  }
 
-    @media (--md) {
+  @media (--md) {
+    div {
       max-width: min(65ch, 60%);
     }
+  }
 
-    &[data-wide='true'] {
-      @media (--md) {
-        max-width: none;
-      }
+  @media (--md) {
+    div[data-wide='true'] {
+      max-width: none;
     }
+  }
 
-    & :global(p:not(:last-child)) {
-      margin-block-end: 1em;
-    }
+  div :global(p:not(:last-child)) {
+    margin-block-end: 1em;
+  }
 
-    & :global(h3) {
-      font-weight: bold;
-      margin-block-end: 0.75em;
-    }
+  div :global(h3) {
+    font-weight: bold;
+    margin-block-end: 0.75em;
+  }
 
-    & :global(h4) {
-      font-weight: bold;
-      margin-block-end: 0.75em;
-    }
+  div :global(h4) {
+    font-weight: bold;
+    margin-block-end: 0.75em;
+  }
 
-    /* Inline code styling */
-    & :global(code) {
-      font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
-      font-size: 0.8em;
-      background-color: var(--color-light-gray);
-      padding: 0.125em 0.25em;
-      border-radius: 0.25em;
-      color: var(--color-primary);
-    }
+  /* Inline code styling */
+  div :global(code) {
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.8em;
+    background-color: var(--color-light-gray);
+    padding: 0.125em 0.25em;
+    border-radius: 0.25em;
+    color: var(--color-primary);
+  }
 
-    & :global(ul),
-    & :global(ol) {
-      list-style: revert;
-      padding-inline-start: 1em;
-    }
+  div :global(ul),
+  div :global(ol) {
+    list-style: revert;
+    padding-inline-start: 1em;
+  }
 
-    & :global(li) {
-      margin-block: 0.5em;
-    }
+  div :global(li) {
+    margin-block: 0.5em;
+  }
 
-    /* Link styling - SCOPED to Prose components only */
-    & :global(a) {
-      word-break: break-word;
-      color: var(--color-text);
-      text-decoration: underline;
-      text-decoration-color: var(--color-gray);
-      text-underline-offset: 0.2em;
-      text-decoration-thickness: 0.1em;
-      transition: all var(--animation-duration) ease;
-    }
+  /* Link styling - SCOPED to Prose components only */
+  div :global(a) {
+    word-break: break-word;
+    color: var(--color-text);
+    text-decoration: underline;
+    text-decoration-color: var(--color-gray);
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 0.1em;
+    transition: all var(--animation-duration) ease;
+  }
 
-    & :global(a:hover) {
-      color: var(--color-primary);
-      text-decoration-color: var(--color-primary);
-      text-decoration-thickness: 0.15em;
-    }
+  div :global(a:hover) {
+    color: var(--color-primary);
+    text-decoration-color: var(--color-primary);
+    text-decoration-thickness: 0.15em;
+  }
 
-    & :global(a:focus-visible) {
-      outline: 0.125rem solid var(--color-focus);
-      outline-offset: 0.125rem;
-      border-radius: 0.125rem;
-    }
+  div :global(a:focus-visible) {
+    outline: 0.125rem solid var(--color-focus);
+    outline-offset: 0.125rem;
+    border-radius: 0.125rem;
+  }
 
-    /* External links get the external icon */
-    & :global(a[href^='http']) {
-      position: relative;
-    }
+  /* External links get the external icon */
+  div :global(a[href^='http']) {
+    position: relative;
+  }
 
-    & :global(a[href^='http'])::after {
-      content: '';
-      display: inline-block;
-      width: 0.8em;
-      height: 0.8em;
-      margin-inline-start: 0.25em;
-      opacity: 0.7;
-      transition: opacity var(--animation-duration) ease;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E");
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: center;
-      vertical-align: baseline;
-    }
+  div :global(a[href^='http'])::after {
+    content: '';
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    margin-inline-start: 0.25em;
+    opacity: 0.7;
+    transition: opacity var(--animation-duration) ease;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    vertical-align: baseline;
+  }
 
-    & :global(a[href^='http']:hover)::after {
-      opacity: 1;
-    }
+  div :global(a[href^='http']:hover)::after {
+    opacity: 1;
+  }
 
-    /* Internal anchor links */
-    & :global(a[href^='#']:hover) {
-      color: var(--color-accent);
-      text-decoration-color: var(--color-accent);
-    }
+  /* Internal anchor links */
+  div :global(a[href^='#']:hover) {
+    color: var(--color-accent);
+    text-decoration-color: var(--color-accent);
+  }
 
-    /* Italic styling - SCOPED to Prose components only */
-    & :global(i),
-    & :global(em) {
-      font-style: italic;
-    }
+  /* Italic styling - SCOPED to Prose components only */
+  div :global(i),
+  div :global(em) {
+    font-style: italic;
+  }
 
-    /* Bold styling - SCOPED to Prose components only */
-    & :global(b),
-    & :global(strong) {
-      font-weight: var(--font-weight-semibold);
-    }
+  /* Bold styling - SCOPED to Prose components only */
+  div :global(b),
+  div :global(strong) {
+    font-weight: var(--font-weight-semibold);
   }
 </style>

--- a/src/content/handbook/01-prinsipper.mdx
+++ b/src/content/handbook/01-prinsipper.mdx
@@ -6,18 +6,15 @@ order: 1
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Kynd er til for oss, vi eier og bygger Kynd sammen, vi er alle *kompanjonger*. Vi er en gjeng
-    som liker faget vårt, og som syns det skal være gøy og givende å bygge Kynd, et selskap av og
-    for de ansatte. Prinsippet er førende for alt vi gjør med pengebruk, fakturering, turer, you
-    name it. Vår lojalitet er primært til hverandre, til våre nære relasjoner, og til selskapet
-    vårt.
-  </p>
-  <p>
-    Idéen om Kynd ble født ut av en verdi-diskusjon. Vi tror på, og står for, verdiene våre, og
-    bruker dem som utgangspunkt for hvordan vi driver sjappa. Ellers lever vi etter følgende
-    tankesett:
-  </p>
+  Kynd er til for oss, vi eier og bygger Kynd sammen, vi er alle *kompanjonger*. Vi er en gjeng som
+  liker faget vårt, og som syns det skal være gøy og givende å bygge Kynd, et selskap av og for de
+  ansatte. Prinsippet er førende for alt vi gjør med pengebruk, fakturering, turer, you name it.
+  Vår lojalitet er primært til hverandre, til våre nære relasjoner, og til selskapet vårt.
+
+Idéen om Kynd ble født ut av en verdi-diskusjon. Vi tror på, og står for, verdiene våre, og
+bruker dem som utgangspunkt for hvordan vi driver sjappa. Ellers lever vi etter følgende
+tankesett:
+
 </Prose>
 
 <Prose align="right">

--- a/src/content/handbook/02-hygge.mdx
+++ b/src/content/handbook/02-hygge.mdx
@@ -7,32 +7,29 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="kontoret">Kontoret</h3>
-  <p>
-    Vi deler kontor med fabelaktige [Konfidens](https://www.konfidens.no/) i [Nedre vaskegang
-    6](https://maps.app.goo.gl/3pfyhaaFU4fvrdWe6). Siden vi er en sosial gjeng, forsøker vi å gjøre
-    kontoret til et sosialt samlingspunkt – og intet kontor blir trivelig uten mennesker. Her har vi
-    tipp-topp arbeidsplasser, med store skjermer, ladere, egne tastatur/mus/trackpads/whatever your
-    needs, førsteklasses kontorstoler levert av [Malmstolen](https://malmstolen.no/), levende
-    planter, snacks og kjøleskap med forfriskninger.
-  </p>
-  <p>
-    Målet er å skape et så godt arbeidsmiljø som mulig, både fysisk og kulturet, tilpasset hver
-    kompanjong sine behov.
-  </p>
-  <p>Se også [Arbeidstid og arbeidssted](#arbeidstid-og-arbeidssted).</p>
+  Vi deler kontor med fabelaktige [Konfidens](https://www.konfidens.no/) i [Nedre vaskegang
+  6](https://maps.app.goo.gl/3pfyhaaFU4fvrdWe6). Siden vi er en sosial gjeng, forsøker vi å gjøre
+  kontoret til et sosialt samlingspunkt – og intet kontor blir trivelig uten mennesker. Her har vi
+  tipp-topp arbeidsplasser, med store skjermer, ladere, egne tastatur/mus/trackpads/whatever your
+  needs, førsteklasses kontorstoler levert av [Malmstolen](https://malmstolen.no/), levende
+  planter, snacks og kjøleskap med forfriskninger.
+
+Målet er å skape et så godt arbeidsmiljø som mulig, både fysisk og kulturet, tilpasset hver
+kompanjong sine behov.
+
+Se også [Arbeidstid og arbeidssted](#arbeidstid-og-arbeidssted).
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="arbeidstid-og-arbeidssted">Arbeidstid og arbeidssted</h3>
-  <p>Content about work hours and workplace will go here...</p>
+  Content about work hours and workplace will go here...
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="fest-og-fjas">Fest og fjas</h3>
-  <p>
-    Delt verdigrunnlag er byggeklossene, sosiale aktiviteter til hverdag og fest, er limet. En
-    ikke-uttømmende liste over arrangementer vi har eller ønsker å etablere er:
-  </p>
+  Delt verdigrunnlag er byggeklossene, sosiale aktiviteter til hverdag og fest, er limet. En
+  ikke-uttømmende liste over arrangementer vi har eller ønsker å etablere er:
 </Prose>
 
 <Prose align="right">
@@ -62,15 +59,13 @@ import Prose from '@/components/Prose.astro';
 </Prose>
 
 <Prose align="right" wide="true">
-  <p>
-    I tillegg har vi bidratt med øknomisk spons, arbeidskapasitet og erfaring for å gjennomføre Los
-    Tacos Miles (LTM) i 2024 og 2025.
-  </p>
+  I tillegg har vi bidratt med øknomisk spons, arbeidskapasitet og erfaring for å gjennomføre Los
+  Tacos Miles (LTM) i 2024 og 2025.
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="moteplasser">Møteplasser</h3>
-  <p>Vi har (foreløpig) følgende faste møtepunkter:</p>
+  Vi har (foreløpig) følgende faste møtepunkter:
   <ul>
     <li>Forkynd – styremøte, hver uke. Alle er invitert, alltid. Styremedlemmer har stemmerett.</li>
     <li>
@@ -91,7 +86,7 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="daglig-kommunikasjon">Daglig kommunikasjon</h3>
-  <p>Basics vi forholder oss til i hverdagen er:</p>
+  Basics vi forholder oss til i hverdagen er:
   <ul>
     <li>Slack for skriftlig kommunikasjon (selvfølgelig).</li>
     <li>

--- a/src/content/handbook/03-lonn-og-eierskap.mdx
+++ b/src/content/handbook/03-lonn-og-eierskap.mdx
@@ -7,83 +7,72 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="lonn-og-lonsmodell">Lønn og lønnsmodell</h3>
-  <p>
-    I kynd praktiserer vi – foreløpig – flat lønn på 1 MNOK i året, uavhengig av ansiennitet og
-    senioritet. Denne avgjørelsen er ikke skrevet i stein, men så langt har vi ikke sett behov for å
-    endre oppsettet.
-  </p>
-  <p>
-    Vi har helt bevisst unngått en provisjonsbasert lønnsmodell. Kynd er tuftet på gjensidig
-    solidaritet, hvor alle sitter i samme båt. Det betyr at vi deler risikoen for at noen sitter på
-    benk, i stedet for at den risikoen tilfaller arbeidstakeren direkte gjennom en vesentlig
-    lønnsreduksjon. På samme måte betyr det også at det er selskapet, og ikke den ansatte, som tar
-    risikoen for fluktuasjoner i markedet, i stedet for ved provisjon hvor arbeidsgiver reduserer
-    sin lønnskostnad betraktelig.
-  </p>
+  I kynd praktiserer vi – foreløpig – flat lønn på 1 MNOK i året, uavhengig av ansiennitet og
+  senioritet. Denne avgjørelsen er ikke skrevet i stein, men så langt har vi ikke sett behov for å
+  endre oppsettet.
+
+Vi har helt bevisst unngått en provisjonsbasert lønnsmodell. Kynd er tuftet på gjensidig
+solidaritet, hvor alle sitter i samme båt. Det betyr at vi deler risikoen for at noen sitter på
+benk, i stedet for at den risikoen tilfaller arbeidstakeren direkte gjennom en vesentlig
+lønnsreduksjon. På samme måte betyr det også at det er selskapet, og ikke den ansatte, som tar
+risikoen for fluktuasjoner i markedet, i stedet for ved provisjon hvor arbeidsgiver reduserer sin
+lønnskostnad betraktelig.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="overtid">Overtid</h3>
-  <p>
-    Vi har foreløpig ingen ordning om overtid i Kynd. Å bygge selskapet er en «joint effort» som vi
-    leverer til etter beste evne og kapasitet.
-  </p>
-  <p>Se også [utbytte](#utbytte).</p>
+  Vi har foreløpig ingen ordning om overtid i Kynd. Å bygge selskapet er en «joint effort» som vi
+  leverer til etter beste evne og kapasitet.
+
+Se også [utbytte](#utbytte).
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="pensjon">Pensjon</h3>
-  <p>
-    Vi skal alle bli gamle etterhvert. Pensjon er viktig, slik at du kan leve så godt som mulig når
-    du er grå i hårene (hvis du fortsatt har hår).
-  </p>
-  <p>
-    Vår pensjonsleverandør er [Duvi](https://duvi.no/). Vi setter av 7 % opp til 12 G, og 7 % over
-    12 G til din pensjon.
-  </p>
+  Vi skal alle bli gamle etterhvert. Pensjon er viktig, slik at du kan leve så godt som mulig når
+  du er grå i hårene (hvis du fortsatt har hår).
+
+Vår pensjonsleverandør er [Duvi](https://duvi.no/). Vi setter av 7 % opp til 12 G, og 7 % over
+12 G til din pensjon.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="eierskapsmodell">Eierskapsmodell</h3>
-  <p>
-    Bærende prinsipp for eierskapsmodellen vår er at ingen kompanjong i Kynd skal ha rett til å eie
-    mer av selskapet enn andre kompanjonger.
-  </p>
-  <p>
-    Alle ansatte i Kynd får tilbud, og oppfordring, om å kjøpe 1/n-del av aksjene i selskapet, hvor
-    n er antall kompanjonger. Kynd er behjelpelig med finansiering, så et medeierskap ikke skal
-    medføre unødvendig økonomisk belastning for kompanjongen.
-  </p>
-  <p>
-    For å ha en forutsigbar prismodell for aksjene, følger vi formuesverdien til selskapet. I følge
-    Skatteetaten er formuesverdien 80 % av egenkapitalen.
-  </p>
-  <p>
-    Inntil vi når en viss størrelse, vil all omsetting av aksjer foregå ved at eksisterende
-    kompanjonger selger en del av sin aksjebeholdning til den nyervervede kollegaen. Dette gir både
-    litt økonomisk uttelling for eksisterende kompanjonger, og et insentiv for at vi skal bli flere
-    på en bærekraftig og trivelig måte.
-  </p>
+  Bærende prinsipp for eierskapsmodellen vår er at ingen kompanjong i Kynd skal ha rett til å eie
+  mer av selskapet enn andre kompanjonger.
+
+Alle ansatte i Kynd får tilbud, og oppfordring, om å kjøpe 1/n-del av aksjene i selskapet, hvor n
+er antall kompanjonger. Kynd er behjelpelig med finansiering, så et medeierskap ikke skal medføre
+unødvendig økonomisk belastning for kompanjongen.
+
+For å ha en forutsigbar prismodell for aksjene, følger vi formuesverdien til selskapet. I følge
+Skatteetaten er formuesverdien 80 % av egenkapitalen.
+
+Inntil vi når en viss størrelse, vil all omsetting av aksjer foregå ved at eksisterende
+kompanjonger selger en del av sin aksjebeholdning til den nyervervede kollegaen. Dette gir både
+litt økonomisk uttelling for eksisterende kompanjonger, og et insentiv for at vi skal bli flere
+på en bærekraftig og trivelig måte.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="utbytte">Utbytte</h3>
-  <p>
-    Delt og likt eierskap betyr likt utbytte for alle kompanjonger. Utbytte er vårt verktøy for å
-    holde egenkapitalen, og dermed også aksjeprisen, til selskapet på et nivå som gir trygg og
-    forutsigbar drift av selskapet uten at det er umulig for nye kompanjonger å erverve full
-    aksjepost i selskapet.
-  </p>
-  <p>
-    Siden vi har en lønnsmodell som er fristilt fra faktureringsgrad, og dermed øker risikoen for
-    selskapet når markedet er vanskelig, betyr det at vi trenger en solid buffer. Det er like fullt
-    vårt mål å utbetale et lite utbytte i trange tider, og solid utbytte når sjappa går så det
-    suser.
-  </p>
-  <p>
-    Langsiktig ønsker vi å holde egenkapitalen i selskapet på rundt 300-350 kNOK per ansatt. Alt
-    overskytende utbetales til eierne som utbytte etter styrets anbefaling, og vedtas i en
-    ekstraordinær generalforsamling mot slutten av året.
-  </p>
-  <p>Alle kompanjonger har rett til utbytte, uavhengig av tidspunkt på året for ansettelse.</p>
+  Delt og likt eierskap betyr likt utbytte for alle kompanjonger. Utbytte er vårt verktøy for å
+  holde egenkapitalen, og dermed også aksjeprisen, til selskapet på et nivå som gir trygg og
+  forutsigbar drift av selskapet uten at det er umulig for nye kompanjonger å erverve full aksjepost
+  i selskapet.
+
+Siden vi har en lønnsmodell som er fristilt fra faktureringsgrad, og dermed øker risikoen for
+selskapet når markedet er vanskelig, betyr det at vi trenger en solid buffer. Det er like fullt
+vårt mål å utbetale et lite utbytte i trange tider, og solid utbytte når sjappa går så det suser.
+
+Langsiktig ønsker vi å holde egenkapitalen i selskapet på rundt 300-350 kNOK per ansatt. Alt
+overskytende utbetales til eierne som utbytte etter styrets anbefaling, og vedtas i en
+ekstraordinær generalforsamling mot slutten av året.
+
+Alle kompanjonger har rett til utbytte, uavhengig av tidspunkt på året for ansettelse.
+
 </Prose>

--- a/src/content/handbook/04-vare-penger.mdx
+++ b/src/content/handbook/04-vare-penger.mdx
@@ -7,166 +7,149 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="frihet-og-ansvar">Frihet og ansvar</h3>
-  <p>
-    I Kynd er vi alle likeverdige medeiere, så Kynds penger er dine penger. Alle kompanjonger har
-    full tilgang til Fiken, og hele vår økonomi er dønn transparent for alle. Vi har jevnlige
-    gjennomgang av regnskapet i Forkynd.
-  </p>
-  <p>
-    Vi har to ekstra prinsipper for bruk av våre penger:
-    <ol>
-      <li>Det må være regnskapsmessig lovlig pengebruk,</li>
-      <li>Kynd er til for oss, vi ønsker å utnytte handlingsrommet i regnskapsloven.</li>
-    </ol>
-  </p>
+  I Kynd er vi alle likeverdige medeiere, så Kynds penger er dine penger. Alle kompanjonger har full
+  tilgang til Fiken, og hele vår økonomi er dønn transparent for alle. Vi har jevnlige gjennomgang av
+  regnskapet i Forkynd.
+
+Vi har to ekstra prinsipper for bruk av våre penger:
+
+  <ol>
+    <li>Det må være regnskapsmessig lovlig pengebruk,</li>
+    <li>Kynd er til for oss, vi ønsker å utnytte handlingsrommet i regnskapsloven.</li>
+  </ol>
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="folio">Folio</h3>
-  <p>
-    Som kompanjong får du ditt eget Folio debitkort med 20k kronasjer på. Kortet påfylles automatisk
-    når saldo dupper under 10k. Siden Folio er direkte integrert mot Fiken, er din jobb enkel:
-    <ul>
-      <li>bruk kortet – dropp private utlegg for å gjøre regnskapsføringa enklere, og</li>
-      <li>bruk appen, og ta bilde av kvittering av kjøp sporenstreks.</li>
-    </ul>
-  </p>
-  <p>Resten fikser daglig tjener, og purrer hvis du glemmer noe 😊</p>
+  Som kompanjong får du ditt eget Folio debitkort med 20k kronasjer på. Kortet påfylles automatisk
+  når saldo dupper under 10k. Siden Folio er direkte integrert mot Fiken, er din jobb enkel:
+
+<ul>
+  <li>bruk kortet – dropp private utlegg for å gjøre regnskapsføringa enklere, og</li>
+  <li>bruk appen, og ta bilde av kvittering av kjøp sporenstreks.</li>
+</ul>
+
+Resten fikser daglig tjener, og purrer hvis du glemmer noe 😊
+
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="fiken">Fiken</h3>
-  <p>
-    Vi bruker Fiken som regnskapsprogram, og alle kompanjonger får full lesetilgang. Her fører du
-    timer, og du kan følge med på selskapets økonomi.
-  </p>
+  Vi bruker Fiken som regnskapsprogram, og alle kompanjonger får full lesetilgang. Her fører du
+  timer, og du kan følge med på selskapets økonomi.
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="software">Software</h3>
-  <p>
-    Alt du trenger til jobb går selvfølgelig rett på Kynd:
-    <ul>
-      <li>AI-verktøy (ChatGPT, Anthropic, Gemini, etc.)</li>
-      <li>Din favoritt-IDE</li>
-      <li>Passord Manager (se også [sikkerhet](#sikkerhet))</li>
-      <li>
-        Diverse skytjenester ([Supabase](https://supabase.com/), [Railway](https://railway.app/),
-        etc.) (se også [Utstyr](#utstyr))
-      </li>
-      <li>Ymse software, som e-postklienter, apper, og så videre.</li>
-    </ul>
-  </p>
+  Alt du trenger til jobb går selvfølgelig rett på Kynd:
+
+  <ul>
+    <li>AI-verktøy (ChatGPT, Anthropic, Gemini, etc.)</li>
+    <li>Din favoritt-IDE</li>
+    <li>Passord Manager (se også [sikkerhet](#sikkerhet))</li>
+    <li>
+      Diverse skytjenester ([Supabase](https://supabase.com/), [Railway](https://railway.app/),
+      etc.) (se også [Utstyr](#utstyr))
+    </li>
+    <li>Ymse software, som e-postklienter, apper, og så videre.</li>
+  </ul>
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="boker-og-tidsskrift">Bøker og tidsskrift</h3>
-  <p>
-    Kjøp det du føler du trenger for å holde deg oppdatert. Føres opp i Utstyrsoversikten hvis
-    kostnad over et år er mer enn 1000 kroner.
-  </p>
-  <p>
-    Eksempler: [Shifter](https://shifter.no/), [Digi.no](https://digi.no/), [Team
-    Topologies](https://teamtopologies.com/), [Phoenix
-    Project](https://www.amazon.com/Phoenix-Project-DevOps-Helping-Business/dp/0988262592),
-    [Aftenposten](https://www.aftenposten.no/), [DN](https://www.dn.no/), m.m.
-  </p>
+  Kjøp det du føler du trenger for å holde deg oppdatert. Føres opp i Utstyrsoversikten hvis kostnad
+  over et år er mer enn 1000 kroner.
+
+Eksempler: [Shifter](https://shifter.no/), [Digi.no](https://digi.no/), [Team
+Topologies](https://teamtopologies.com/), [Phoenix
+Project](https://www.amazon.com/Phoenix-Project-DevOps-Helping-Business/dp/0988262592),
+[Aftenposten](https://www.aftenposten.no/), [DN](https://www.dn.no/), m.m.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="utstyr">Utstyr</h3>
-  <p>
-    Alt utstyr som kan anses som relevant for jobb settes på selskapet, og føres i Utstyrsoversikten
-    hvis det koster mer enn 1000 kroner.
-  </p>
-  <p>
-    Eksempler: laptop, skjermer, headsets, tastatur/mus, mikrofon, nettverk, skrivebord, stol,
-    webcam, dockingstasjon til laptop og mobil, telefon, telefonbeskyttelse, smartklokker (hvis du
-    utvikler greier til dem, se også [Produkttid](#produkttid)), nettbrett (iPads, osv.), powerbank
-    når du er på farta – you name it.
-  </p>
+  Alt utstyr som kan anses som relevant for jobb settes på selskapet, og føres i Utstyrsoversikten
+  hvis det koster mer enn 1000 kroner.
+
+Eksempler: laptop, skjermer, headsets, tastatur/mus, mikrofon, nettverk, skrivebord, stol,
+webcam, dockingstasjon til laptop og mobil, telefon, telefonbeskyttelse, smartklokker (hvis du
+utvikler greier til dem, se også [Produkttid](#produkttid)), nettbrett (iPads, osv.), powerbank når
+du er på farta – you name it.
+
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="utstyrsbudsjett">Utstyrsbudsjett</h3>
-  <p>
-    Vi praktiserer ikke utstyrsbudsjett, men viser (igjen) til enkle prinsipper om:
-    <ul>
-      <li>reelt behov,</li>
-      <li>vurder mulighet for gjenbruk,</li>
-      <li>selskapets økonmi</li>
-    </ul>
-  </p>
-  <p>
-    Det betyr: du kjøper det du trenger når du trenger det, og så tar vi det derfra. Vi har derimot
-    en søt liten [👑
-    Utstyrsliste](https://www.notion.so/kynd-hq/1767533a50b1807f87a6f635e891c668?v=1767533a50b181519bed000c2d4d593e&source=copy_link)
-    (krever autentisering) for å synliggjøre for alle hva vi kjøper med en årskostnad på over 1000
-    NOK.
-  </p>
+  Vi praktiserer ikke utstyrsbudsjett, men viser (igjen) til enkle prinsipper om:
+
+<ul>
+  <li>reelt behov,</li>
+  <li>vurder mulighet for gjenbruk,</li>
+  <li>selskapets økonmi</li>
+</ul>
+
+Det betyr: du kjøper det du trenger når du trenger det, og så tar vi det derfra. Vi har derimot en
+søt liten [👑
+Utstyrsliste](https://www.notion.so/kynd-hq/1767533a50b1807f87a6f635e891c668?v=1767533a50b181519bed000c2d4d593e&source=copy_link)
+(krever autentisering) for å synliggjøre for alle hva vi kjøper med en årskostnad på over 1000 NOK.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="telefon">Telefon</h3>
-  <p>
-    Kynd dekker selvfølgelig ønsket telefon og telefonabonnement. Abonnementet leveres fra
-    Chilimobil, naturligvis med ubegrenset data.
-  </p>
+  Kynd dekker selvfølgelig ønsket telefon og telefonabonnement. Abonnementet leveres fra Chilimobil,
+  naturligvis med ubegrenset data.
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="overtidsmat">Overtidsmat</h3>
-  <p>
-    I kynd har vi ingen selvpålagt begrensninger på bruk av overtidsmat ut over det som er lovpålagt
-    fra regnskapsloven. Vi har følgende føringer: kjøp overtidsmat så ofte du vil.
-  </p>
-  <p>
-    Kravet fra regnskapsloven er:
-    <ol>
-      <li>
-        Den ansatte må jobbe minst 10 timer (måltidet kan være når som helst i løpet av dagen), og
-      </li>
-      <li>kjøp av mat per ansatt per dag kan være opp til 200 NOK.</li>
-    </ol>
-  </p>
-  <p>
-    Beløp overskytende de rause 200 kronene, må fordelsbeskattes. Siden det godt skal gjøres å få et
-    måltid overtidsmat under 200, kjører vi en oppsummering mot slutten av regnskapsåret. Fordelen
-    vil synliggjøres som «Andre fordeler» på lønnsslippen din for desember.
-  </p>
+  I kynd har vi ingen selvpålagt begrensninger på bruk av overtidsmat ut over det som er lovpålagt
+  fra regnskapsloven. Vi har følgende føringer: kjøp overtidsmat så ofte du vil.
+
+Kravet fra regnskapsloven er:
+
+<ol>
+  <li>
+    Den ansatte må jobbe minst 10 timer (måltidet kan være når som helst i løpet av dagen), og
+  </li>
+  <li>kjøp av mat per ansatt per dag kan være opp til 200 NOK.</li>
+</ol>
+
+Beløp overskytende de rause 200 kronene, må fordelsbeskattes. Siden det godt skal gjøres å få et
+måltid overtidsmat under 200, kjører vi en oppsummering mot slutten av regnskapsåret. Fordelen vil
+synliggjøres som «Andre fordeler» på lønnsslippen din for desember.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="merch">Merch</h3>
-  <p>Vi digger merch! Kynd er vår merkevare, og vi bruker selvfølgelig drakta til laget vårt.</p>
-  <p>
-    Kjøp det du føler for, så lenge vi kan trykke eller brodere logo på. Tidligere har vi kjøpt inn
-    litt generell merch som deilige gensere, t-skjorter og capser fra naboen vår 10-10, som leverer
-    både trykk og plagg av ypperste kvalitet og med hensyn til miljøet og tekstilproduksjon.
-  </p>
-  <p>
-    Vi opererer skjønnsmessig på pris. Det er unødvendig med en Louis Vitton-laptop-bag, men vi er
-    opptatt av god kvalitet på merch med tanke på miljø og varighet.
-  </p>
-  <p>
-    Eksempler på annen merch en eller flere i selskapet har, så langt er: laptopvesker, sekk,
-    drikkeflasker.
-  </p>
+  Vi digger merch! Kynd er vår merkevare, og vi bruker selvfølgelig drakta til laget vårt.
+
+Kjøp det du føler for, så lenge vi kan trykke eller brodere logo på. Tidligere har vi kjøpt inn
+litt generell merch som deilige gensere, t-skjorter og capser fra naboen vår 10-10, som leverer
+både trykk og plagg av ypperste kvalitet og med hensyn til miljøet og tekstilproduksjon.
+
+Vi opererer skjønnsmessig på pris. Det er unødvendig med en Louis Vitton-laptop-bag, men vi er
+opptatt av god kvalitet på merch med tanke på miljø og varighet.
+
+Eksempler på annen merch en eller flere i selskapet har, så langt er: laptopvesker, sekk,
+drikkeflasker.
+
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="andre-goder">Andre goder</h3>
-  <p>
-    Vi har flere felles goder for å ta vare på kompanjongene våre. Flere av godene må dessverre
-    fordelsbeskattes, og trekkes samlet i desember.
-    <ul>
-      <li>Lovpålagte forsikringer som Ansvarsforsikring IKT og Yrkesskade</li>
-      <li>
-        Helse-, fritidsulykke- og reiseforsikring leveres av Tryg forsikring. Se Notion eller Drive
-        for detaljer.
-      </li>
-      <li>Betalt lunsj (kantinetrekk på lønnsslippen), og</li>
-      <li>Squeeze-abonnement.</li>
-    </ul>
-  </p>
+  Vi har flere felles goder for å ta vare på kompanjongene våre. Flere av godene må dessverre
+  fordelsbeskattes, og trekkes samlet i desember.
+
+  <ul>
+    <li>Lovpålagte forsikringer som Ansvarsforsikring IKT og Yrkesskade</li>
+    <li>
+      Helse-, fritidsulykke- og reiseforsikring leveres av Tryg forsikring. Se Notion eller Drive for
+      detaljer.
+    </li>
+    <li>Betalt lunsj (kantinetrekk på lønnsslippen), og</li>
+    <li>Squeeze-abonnement.</li>
+  </ul>
 </Prose>

--- a/src/content/handbook/05-produkttid-og-kompetanse.mdx
+++ b/src/content/handbook/05-produkttid-og-kompetanse.mdx
@@ -6,81 +6,68 @@ order: 5
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Vi lever av hodene våre, og vår faglige utvikling er *kjempeviktig.* Som i all læring, får vi
-    mest igjen for det vi bruker mye tid på, for vår del vil det hovedsakelig være kundearbeid.
-  </p>
-  <p>
-    Samtidig har vi i Kynd et uttalt mål om å eksperimentere med teknologier, brukeropplevelse og
-    tjenesteutvikling.
-  </p>
-  <p>
-    En del av vår strategi er å bruke deler av overskuddet på ikke-fakturere aktiviteter vi får
-    kompetansemessig, og kanskje økonomisk, avkastning av i fremtiden. Det betyr at vi prioriterer å
-    investere i konferanser og produkttid, og kostnader som måtte påløpe som en naturlig del av å
-    bygge cloud-baserte tjenester.
-  </p>
+  Vi lever av hodene våre, og vår faglige utvikling er *kjempeviktig.* Som i all læring, får vi mest
+  igjen for det vi bruker mye tid på, for vår del vil det hovedsakelig være kundearbeid.
+
+Samtidig har vi i Kynd et uttalt mål om å eksperimentere med teknologier, brukeropplevelse og
+tjenesteutvikling.
+
+En del av vår strategi er å bruke deler av overskuddet på ikke-fakturere aktiviteter vi får
+kompetansemessig, og kanskje økonomisk, avkastning av i fremtiden. Det betyr at vi prioriterer å
+investere i konferanser og produkttid, og kostnader som måtte påløpe som en naturlig del av å
+bygge cloud-baserte tjenester.
+
 </Prose>
 
 <Prose align="left" wide="true">
   <h3 id="produkttid">Produkttid</h3>
-  <p>
-    Vi utforsker forskjellige måter vi kan bruke tid på å lage egne produkter og tjenester mens vi
-    utforsker teknologier og lærer om tjenesteutvikling.
-  </p>
-  <p>
-    Foreløpig har dette arbeidet vært gjort «på si». Vi har en egen Slack-kanal for brainstorming av
-    idéer, og egne kanaler for arbeid som gjøres på faktiske tjenester. Se også
-    [kynd.no/labs](https://kynd.no/labs).
-  </p>
-  <p>
-    For 2026 budsjetterer vi med 10 fulle produktdager, som vi tror vi skal kombinere med Workation
-    og eller Strategisamling (se også [Strategisamlinger](#strategisamlinger)).
-  </p>
+  Vi utforsker forskjellige måter vi kan bruke tid på å lage egne produkter og tjenester mens vi
+  utforsker teknologier og lærer om tjenesteutvikling.
+
+Foreløpig har dette arbeidet vært gjort «på si». Vi har en egen Slack-kanal for brainstorming av
+idéer, og egne kanaler for arbeid som gjøres på faktiske tjenester. Se også
+[kynd.no/labs](https://kynd.no/labs).
+
+For 2026 budsjetterer vi med 10 fulle produktdager, som vi tror vi skal kombinere med Workation og
+eller Strategisamling (se også [Strategisamlinger](#strategisamlinger)).
+
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="konferanser">Konferanser</h3>
-  <p>
-    Enkel prosess: vil du dra på konferanse? Knall! Lag en kort pitch til resten av kompanjongene,
-    og så forsøker vi å få dratt alle sammen for å kombinere kunnskapsbygging og sosialisering innad
-    i selskapet.
-  </p>
-  <p>
-    Så langt har vi vært på
-    <ul>
-      <li>Unconference, [smidig.no](http://smidig.no) (Oslo, Norge)</li>
-    </ul>
-  </p>
-  <p>
-    Inspirasjonsliste for fremtidige konferanser:
-    <ul>
-      <li>[DEVWORLD](https://devworldconference.com/) (Amsterdam, Nederland)</li>
-      <li>[QCon London](https://qconlondon.com/) (London, UK)</li>
-      <li>
-        [Kode24-dagen](https://dev.events/conferences/kode24-dagen-4-0-uil-oyfg) (Oslo, Norge)
-      </li>
-      <li>[DevFest Stockholm](https://www.devfest-stockholm.com/) (Stockholm, Sverige)</li>
-      <li>[T3chFest](https://dev.events/conferences/t3chfest-2025-mi-wygsy) (Madrid, Spania)</li>
-      <li>
-        [Soft Skills fwdays](https://fwdays.com/en/event/soft-skills-fwdays-2025) (Kyiv, Ukraina)
-      </li>
-      <li>
-        [Agile Meets Architecture](https://www.agile-meets-architecture.com/2025/home) (Berlin,
-        Tyskland)
-      </li>
-      <li>[Product at Heart](https://productatheart.com/) (Hamburg, Tyskland)</li>
-    </ul>
-  </p>
+  Enkel prosess: vil du dra på konferanse? Knall! Lag en kort pitch til resten av kompanjongene, og
+  så forsøker vi å få dratt alle sammen for å kombinere kunnskapsbygging og sosialisering innad i
+  selskapet.
+
+Så langt har vi vært på
+
+<ul>
+  <li>Unconference, [smidig.no](http://smidig.no) (Oslo, Norge)</li>
+</ul>
+
+Inspirasjonsliste for fremtidige konferanser:
+
+  <ul>
+    <li>[DEVWORLD](https://devworldconference.com/) (Amsterdam, Nederland)</li>
+    <li>[QCon London](https://qconlondon.com/) (London, UK)</li>
+    <li>[Kode24-dagen](https://dev.events/conferences/kode24-dagen-4-0-uil-oyfg) (Oslo, Norge)</li>
+    <li>[DevFest Stockholm](https://www.devfest-stockholm.com/) (Stockholm, Sverige)</li>
+    <li>[T3chFest](https://dev.events/conferences/t3chfest-2025-mi-wygsy) (Madrid, Spania)</li>
+    <li>[Soft Skills fwdays](https://fwdays.com/en/event/soft-skills-fwdays-2025) (Kyiv, Ukraina)</li>
+    <li>
+      [Agile Meets Architecture](https://www.agile-meets-architecture.com/2025/home) (Berlin,
+      Tyskland)
+    </li>
+    <li>[Product at Heart](https://productatheart.com/) (Hamburg, Tyskland)</li>
+  </ul>
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="kurs-og-sertifiseringer">Kurs og sertifiseringer</h3>
-  <p>
-    Du drar på de kursene og tar de sertifiseringene du trenger og finner interessant. Skriv en kort
-    pitch, se om andre vil være med på læringsreisen, bestill og betal med Folio, og do what you do.
-    <ul>
-      <li>Team Topologies Masterclass (Oslo, Norge)</li>
-    </ul>
-  </p>
+  Du drar på de kursene og tar de sertifiseringene du trenger og finner interessant. Skriv en kort
+  pitch, se om andre vil være med på læringsreisen, bestill og betal med Folio, og do what you do.
+
+  <ul>
+    <li>Team Topologies Masterclass (Oslo, Norge)</li>
+  </ul>
 </Prose>

--- a/src/content/handbook/06-verdiproduksjon.mdx
+++ b/src/content/handbook/06-verdiproduksjon.mdx
@@ -27,7 +27,8 @@ så fall er det daglig tjener.
 </Prose>
 
 <Prose align="left" wide="true">
-  <h3 id="produkter">Produkter</h3>I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare
+  <h3 id="produkter">Produkter</h3>
+  I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare
   selge hodene våre. Vi utforsker for tiden hvordan vi kan kombinere kompetanseheving og
   produktutvikling på en funksjonell og inspirerende måte. Se [Produkttid](#produkttid) og
   [Kompetanse](#kompetanse).

--- a/src/content/handbook/06-verdiproduksjon.mdx
+++ b/src/content/handbook/06-verdiproduksjon.mdx
@@ -27,8 +27,7 @@ så fall er det daglig tjener.
 </Prose>
 
 <Prose align="left" wide="true">
-  <h3 id="produkter">Produkter</h3>
-  I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare
+  <h3 id="produkter">Produkter</h3>I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare
   selge hodene våre. Vi utforsker for tiden hvordan vi kan kombinere kompetanseheving og
   produktutvikling på en funksjonell og inspirerende måte. Se [Produkttid](#produkttid) og
   [Kompetanse](#kompetanse).

--- a/src/content/handbook/06-verdiproduksjon.mdx
+++ b/src/content/handbook/06-verdiproduksjon.mdx
@@ -7,72 +7,60 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="arbeidstid-og-arbeidssted">Arbeidstid og arbeidssted</h3>
-  <p>
-    Fast arbeidstid er 37,5 h i uken, med mindre annet er avtalt eller redegjort for i din
-    individuelle arbeidsavtale.
-  </p>
-  <p>
-    Hjemmekontor er selvfølgelig 100 % fleksibelt, innenfor kundens rammer, og Kynd supplerer alt du
-    måtte trenge for en optimal arbeidsplass hjemme.
-  </p>
-  <p>Se også [Kontoret](#kontoret), [Overtid](#overtid).</p>
+  Fast arbeidstid er 37,5 h i uken, med mindre annet er avtalt eller redegjort for i din individuelle
+  arbeidsavtale.
+
+Hjemmekontor er selvfølgelig 100 % fleksibelt, innenfor kundens rammer, og Kynd supplerer alt du
+måtte trenge for en optimal arbeidsplass hjemme.
+
+Se også [Kontoret](#kontoret), [Overtid](#overtid).
+
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="oppdrag">Oppdrag</h3>
-  <p>Å få oppdrag er en kollektiv innsats.</p>
-  <p>
-    Man er selv ansvarlig for å følge opp eget oppdrag og kunde, med mindre man ikke ønsker det
-    selv, i så fall er det daglig tjener.
-  </p>
+  Å få oppdrag er en kollektiv innsats.
+
+Man er selv ansvarlig for å følge opp eget oppdrag og kunde, med mindre man ikke ønsker det selv, i
+så fall er det daglig tjener.
+
 </Prose>
 
 <Prose align="left" wide="true">
-  <h3 id="produkter">Produkter</h3>
-  <p>
-    I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare selge hodene våre. Vi utforsker for
-    tiden hvordan vi kan kombinere kompetanseheving og produktutvikling på en funksjonell og
-    inspirerende måte. Se [Produkttid](#produkttid) og [Kompetanse](#kompetanse).
-  </p>
+  <h3 id="produkter">Produkter</h3>I Kynd har vi som uttalt mål at vi skal lage ting, ikke bare
+  selge hodene våre. Vi utforsker for tiden hvordan vi kan kombinere kompetanseheving og
+  produktutvikling på en funksjonell og inspirerende måte. Se [Produkttid](#produkttid) og
+  [Kompetanse](#kompetanse).
 </Prose>
 
 <Prose align="right" wide="true">
   <h3 id="timeforing">Timeføring</h3>
-  <p>
-    Vi tjener mesteparten av pengene våre på å selge timer, og må (dessverre) føre alle timer som brukes på Kynd. Dette ønsker vi å gjøre så enkelt som overhode mulig. 
-  </p>
+  Vi tjener mesteparten av pengene våre på å selge timer, og må (dessverre) føre alle timer som
+  brukes på Kynd. Dette ønsker vi å gjøre så enkelt som overhode mulig.
   
   <h4 id="timeforing-fakturering">Bread&Butter: fakturering</h4>
-  <p>
-    Er du i oppdrag? Perfekt! Da finnes det tilhørende prosjekt og aktivitet(er) i Fiken, typisk `kunde > prosjekt`.
-  </p>
+  Er du i oppdrag? Perfekt! Da finnes det tilhørende prosjekt og aktivitet(er) i Fiken, typisk
+  `kunde > prosjekt`.
 
   <h4 id="timeforing-velferdspermisjon">Velferdspermisjon</h4>
-  <p>
-    Gifter du deg? Trenger du flyttedager? Skal du til legen? Konfirmasjon? Begravelse? Tilvenning i barnehagen? Da fører du timene på internprosjekt under aktivitet velferdspermisjon: `intern > velferdspermisjon`.
-  </p>
-  <p>
-    Se også [Permisjon](#permisjon).
-  </p>
+  Gifter du deg? Trenger du flyttedager? Skal du til legen? Konfirmasjon? Begravelse? Tilvenning i
+  barnehagen? Da fører du timene på internprosjekt under aktivitet velferdspermisjon:
+  `intern > velferdspermisjon`.
+
+Se også [Permisjon](#permisjon).
+
   <h4 id="timeforing-ferie">Ferie</h4>
-  <p>
-    Ferie speaks for itself: `intern > ferie`
-  </p>
-  <p>
-    Alternativ aktivitet: `intern > ferie uten lønn`.
-  </p>
+  Ferie speaks for itself: `intern > ferie`
+
+Alternativ aktivitet: `intern > ferie uten lønn`.
+
   <h4 id="timeforing-produkttid">Produkttid</h4>
-  <p>
-    Produkttid er tid som brukes på å utvikle produkter og tjenester, og føres på `intern > produkter`. 
-  </p>
+  Produkttid er tid som brukes på å utvikle produkter og tjenester, og føres på
+  `intern > produkter`.
   <h4 id="sykdom">Sykdom</h4>
-  <p>
-    Før timer på `intern > sykedag`. Se også [Sykdom og fravær](#08-sykdom-og-fravaer).
-  </p>
+  Før timer på `intern > sykedag`. Se også [Sykdom og fravær](#08-sykdom-og-fravaer).
   <h4 id="timeforing-interntid">Interntid</h4>
-  <p>
-    All annen tidsbruk føres på `intern > interntid`.
-  </p>
+  All annen tidsbruk føres på `intern > interntid`.
 </Prose>
 
 <Prose align="left" wide="true"></Prose>

--- a/src/content/handbook/07-ferie-og-feriepenger.mdx
+++ b/src/content/handbook/07-ferie-og-feriepenger.mdx
@@ -7,38 +7,30 @@ import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
   <h3 id="ferie-og-rettigheter">Ferie og rettigheter</h3>
-  <p>
-    Alle er enige: ferie er nice 🤝 I Kynd har vi fem uker betalt ferie, pluss at inneklemte dager i jul og påske selvfølgelig er inkludert. I praksis har vi altså rundt seks uker betalt ferie i året. 
-  </p>
+  Alle er enige: ferie er nice 🤝 I Kynd har vi fem uker betalt ferie, pluss at inneklemte dager i
+  jul og påske selvfølgelig er inkludert. I praksis har vi altså rundt seks uker betalt ferie i året.
 
 <h3 id="ferie-feriefrihet">Feriefrihet</h3>
-<p>
-  Vi tror på frihet, ansvar og medeierskap, og har tidligere år ikke praktisert noen «hard» grense
-  for antall feriedager man kan ta uten at det påvirker din lønn. For å gjøre denne friheten
-  rettferdig, har vi tidligere «balansert» ut feriebruken i selskapet, slik at differensen mellom
-  din ferie og den som har tatt ut mest ferie, utbetales som bonus i januar påfølgende år. Dette er
-  en praksis vi ønsker å tilstrebe innenfor rimelighetens grenser (hva nå dét må være), og avhenger
-  selvfølgelig av Kynds økonomi – tilgang på oppdrag, faktureringsgrad, annerledesdager, etc.
-</p>
+Vi tror på frihet, ansvar og medeierskap, og har tidligere år ikke praktisert noen «hard» grense for
+antall feriedager man kan ta uten at det påvirker din lønn. For å gjøre denne friheten rettferdig,
+har vi tidligere «balansert» ut feriebruken i selskapet, slik at differensen mellom din ferie og den
+som har tatt ut mest ferie, utbetales som bonus i januar påfølgende år. Dette er en praksis vi
+ønsker å tilstrebe innenfor rimelighetens grenser (hva nå dét må være), og avhenger selvfølgelig av
+Kynds økonomi – tilgang på oppdrag, faktureringsgrad, annerledesdager, etc.
 
 <h3 id="ferie-uttak-av-ferie">Uttak av ferie</h3>
-<p>
-  Ferie er viktig, og vi ønsker å være så fleksible som mulig i når du kan ta ut ferien din. Så
-  lenge det funker for kunden, bryr ikke vi oss om du tar ferie i juli eller november.
-</p>
-<p>
-  Er du på benk, endrer det prinsipielt sett ingenting, men vi oppfordrer kompanjongen til å kaste
-  et lite blikk mot selskapets, og dine medeieres, økonomiske situasjon. Vi diskuterer det i
-  Forkynd.
-</p>
-<p>
-  Alle arbeidstakere har plikt til å bruke opp den lovpålagte ferien som er 4 uker og 1 dag. Hvis
-  det er mer til overs kan opptil to uker bli overført til nytt år. Om noe mystisk skulle skje med
-  overføringen, ta kontakt med daglig tjener eller bare sleng ut en melding i Slack.
-</p>
+Ferie er viktig, og vi ønsker å være så fleksible som mulig i når du kan ta ut ferien din. Så lenge
+det funker for kunden, bryr ikke vi oss om du tar ferie i juli eller november.
+
+Er du på benk, endrer det prinsipielt sett ingenting, men vi oppfordrer kompanjongen til å kaste et
+lite blikk mot selskapets, og dine medeieres, økonomiske situasjon. Vi diskuterer det i Forkynd.
+
+Alle arbeidstakere har plikt til å bruke opp den lovpålagte ferien som er 4 uker og 1 dag. Hvis det
+er mer til overs kan opptil to uker bli overført til nytt år. Om noe mystisk skulle skje med
+overføringen, ta kontakt med daglig tjener eller bare sleng ut en melding i Slack.
 
   <h3 id="ferie-feriepenger">Feriepenger</h3>
-  <p>
-    Feriepengene blir utbetalt i forbindelse med lønnskjøring i juni, og bygger på den oppsparte feriepengepotten du opparbeidet deg fra året før. Feriedagene blir trukket i juni uavhengig om du tar ut ferien i juni eller ei. 
-  </p>
+  Feriepengene blir utbetalt i forbindelse med lønnskjøring i juni, og bygger på den oppsparte
+  feriepengepotten du opparbeidet deg fra året før. Feriedagene blir trukket i juni uavhengig om du
+  tar ut ferien i juni eller ei.
 </Prose>

--- a/src/content/handbook/08-sykdom-og-fravaer.mdx
+++ b/src/content/handbook/08-sykdom-og-fravaer.mdx
@@ -6,16 +6,16 @@ order: 8
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Vi oppfordrer til å bruke fleksibiliteten med hjemmekontor, spesielt hvis man er pjusk, og å unngå å kjøre deg i senk – det er verken spesielt hyggelig for dine kolleger, spesielt lønnsomt for Kynd, eller spesielt ålreit for deg å være syk.
-  </p>
-  <p>
-    Vi opererer ikke med maks antall egenmeldinger eller &#8209;perioder, men vi har som arbeidsgiver et dokumentasjonsansvar overfor NAV hvis du er syk i mer enn arbeidsgiverperioden på 16 dager. 
-  </p>
+  Vi oppfordrer til å bruke fleksibiliteten med hjemmekontor, spesielt hvis man er pjusk, og å unngå
+  å kjøre deg i senk – det er verken spesielt hyggelig for dine kolleger, spesielt lønnsomt for
+  Kynd, eller spesielt ålreit for deg å være syk.
+
+Vi opererer ikke med maks antall egenmeldinger eller &#8209;perioder, men vi har som arbeidsgiver et
+dokumentasjonsansvar overfor NAV hvis du er syk i mer enn arbeidsgiverperioden på 16 dager.
 
 <h3 id="sykdom">Sykdom</h3>
-<p>
-  Er du syk, så er du syk. Hold deg hjemme, bli frisk, og så må du huske å:
+Er du syk, så er du syk. Hold deg hjemme, bli frisk, og så må du huske å:
+
   <ul>
     <li>
       føre sykedager i Fiken under aktivitet `intern > sykedag` (se også
@@ -24,20 +24,22 @@ import Prose from '@/components/Prose.astro';
     <li>bruk [helseforsikringa](#helseforsikring) for alt den er verdt, og, ikke minst,</li>
     <li>besøk legen din hvis du tror du er syk i mer enn fem dager. </li>
   </ul>
-</p>
+
 <h3 id="velferdspermisjon">Velferdspermisjon</h3>
-<p>
-  Vi er alle mennesker, og ting skjer i livet som sklir over i arbeidshverdagen. Gifter du deg?
-  Trenger du flyttedag? Skal du til legen? Konfirmasjon? Begravelse? Tilvenning i barnehagen? Lista
-  er lang, og vi følger raushetsprinsippet vårt. Kommuniser med gjengen, så ordner dette seg.
-</p>
-<p>Se også [Timerføring, velferdspermisjon](#timeforing-velferdspermisjon).</p>
+Vi er alle mennesker, og ting skjer i livet som sklir over i arbeidshverdagen. Gifter du deg?
+Trenger du flyttedag? Skal du til legen? Konfirmasjon? Begravelse? Tilvenning i barnehagen? Lista er
+lang, og vi følger raushetsprinsippet vårt. Kommuniser med gjengen, så ordner dette seg.
+
+Se også [Timerføring, velferdspermisjon](#timeforing-velferdspermisjon).
+
 <h3 id="annet-fravaer">Annet fravær</h3>
 
-  <p>
-    Trenger du ulønnet permisjon skal det tungtveiende årsaker til for å avslå det. Et eksempel vil være om ditt fravær vil være til vesentlig ulempe for et prosjekt, uten at det er knakende nødvendig for deg å ta permisjon. Hva «knakende nødvendig» betyr, diskuterer vi åpent i fellesskap. Prinsippet «raushet» gjelder begge veier. 
-  </p>
-  <p>
-    Som for alt er god dialog nøkkelen til suksess, og vi har enda ikke opplevd noen form for utfordring på denne fronten.
-  </p>
+Trenger du ulønnet permisjon skal det tungtveiende årsaker til for å avslå det. Et eksempel vil
+være om ditt fravær vil være til vesentlig ulempe for et prosjekt, uten at det er knakende
+nødvendig for deg å ta permisjon. Hva «knakende nødvendig» betyr, diskuterer vi åpent i fellesskap.
+Prinsippet «raushet» gjelder begge veier.
+
+Som for alt er god dialog nøkkelen til suksess, og vi har enda ikke opplevd noen form for
+utfordring på denne fronten.
+
 </Prose>

--- a/src/content/handbook/09-barn-og-familie.mdx
+++ b/src/content/handbook/09-barn-og-familie.mdx
@@ -6,25 +6,20 @@ order: 9
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Førende prinsipp: kommuniser behov med dine kompanjonger, ta tiden du trenger. Se også [timeføring](#timeforing).
-  </p>
+  Førende prinsipp: kommuniser behov med dine kompanjonger, ta tiden du trenger. Se også
+  [timeføring](#timeforing).
 
-<h3 id="fodsel">Fødsel</h3>
-<p>
-  I forbindelse med fødsel får far eller medmor to uker lønnet permisjon for å hjelpe til hjemme.
-</p>
-<p>Husk å varsle og kunde i god tid.</p>
+<h3 id="fodsel">Fødsel</h3>I forbindelse med fødsel får far eller medmor to uker lønnet permisjon
+for å hjelpe til hjemme.
+
+Husk å varsle og kunde i god tid.
+
 <h3 id="ammefri">Ammefri</h3>
-<p>
-  Ammer du barnet ditt kan du ta ut 1 time betalt ammefri per dag fram til barnet er 20 måneder.
-</p>
+Ammer du barnet ditt kan du ta ut 1 time betalt ammefri per dag fram til barnet er 20 måneder.
 
 <h3 id="omsorgsdager">Omsorgsdager – hjemme med sykt barn</h3>
-<p>https://www.nav.no/arbeidsgiver/omsorgspenger</p>
+https://www.nav.no/arbeidsgiver/omsorgspenger
 
   <h3 id="barnehagetilvenning">Barnehagetilvenning</h3>
-  <p>
-    Også her er vi fleksible: ta den tiden du trenger til barnehagetilvenning.
-  </p>
+  Også her er vi fleksible: ta den tiden du trenger til barnehagetilvenning.
 </Prose>

--- a/src/content/handbook/09-barn-og-familie.mdx
+++ b/src/content/handbook/09-barn-og-familie.mdx
@@ -9,7 +9,8 @@ import Prose from '@/components/Prose.astro';
   Førende prinsipp: kommuniser behov med dine kompanjonger, ta tiden du trenger. Se også
   [timeføring](#timeforing).
 
-<h3 id="fodsel">Fødsel</h3>I forbindelse med fødsel får far eller medmor to uker lønnet permisjon
+<h3 id="fodsel">Fødsel</h3>
+I forbindelse med fødsel får far eller medmor to uker lønnet permisjon
 for å hjelpe til hjemme.
 
 Husk å varsle og kunde i god tid.

--- a/src/content/handbook/09-barn-og-familie.mdx
+++ b/src/content/handbook/09-barn-og-familie.mdx
@@ -9,8 +9,7 @@ import Prose from '@/components/Prose.astro';
   Førende prinsipp: kommuniser behov med dine kompanjonger, ta tiden du trenger. Se også
   [timeføring](#timeforing).
 
-<h3 id="fodsel">Fødsel</h3>
-I forbindelse med fødsel får far eller medmor to uker lønnet permisjon
+<h3 id="fodsel">Fødsel</h3>I forbindelse med fødsel får far eller medmor to uker lønnet permisjon
 for å hjelpe til hjemme.
 
 Husk å varsle og kunde i god tid.

--- a/src/content/handbook/10-sikkerhetskultur.mdx
+++ b/src/content/handbook/10-sikkerhetskultur.mdx
@@ -6,11 +6,9 @@ order: 10
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Som IT-konsulentselskap jobber med kunder med varierende grad av både behov og kompetanse for
-    sikkerhet. Vi ønsker å fungere som sikkerhetsressurser i oppdrag, og internt stiller vi derfor
-    enkle, men effektive krav, til våre kompanjonger
-  </p>
+  Som IT-konsulentselskap jobber med kunder med varierende grad av både behov og kompetanse for
+  sikkerhet. Vi ønsker å fungere som sikkerhetsressurser i oppdrag, og internt stiller vi derfor
+  enkle, men effektive krav, til våre kompanjonger
   <ul>
     <li>Bruk sterke passord og passord-manager. Intet passord skal dupliseres.</li>
     <li>

--- a/src/content/handbook/11-become-one-of-a-kynd.mdx
+++ b/src/content/handbook/11-become-one-of-a-kynd.mdx
@@ -6,17 +6,12 @@ order: 11
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    Vårt delte verdigrunnlag er viktig for oss. Måten vi bygger Kynd på en så forutsigbar som mulig
-    måte i et vanskelig og uforutsigbart marked, gjør at vi er nødt til å stole på hverandre. Vi
-    snakker derfor verken om ansettelsesprosess, intervjuer eller jobbtilbud, men dating og
-    invitasjon.
-  </p>
+  Vårt delte verdigrunnlag er viktig for oss. Måten vi bygger Kynd på en så forutsigbar som mulig
+  måte i et vanskelig og uforutsigbart marked, gjør at vi er nødt til å stole på hverandre. Vi
+  snakker derfor verken om ansettelsesprosess, intervjuer eller jobbtilbud, men dating og invitasjon.
   <h3 id="dating">Dating (bli kjent)</h3>
-  <p>
-    Mål: å bli godt kjent med hverandre. Dette gjør vi påfallende likt «vanlig» dating før
-    datingappenes tid:
-  </p>
+  Mål: å bli godt kjent med hverandre. Dette gjør vi påfallende likt «vanlig» dating før datingappenes
+  tid:
   <ol>
     <li>
       En eller annen form for relasjon etableres, gjerne basert på tidligere samarbeidserfaring
@@ -37,16 +32,14 @@ import Prose from '@/components/Prose.astro';
     </li>
   </ol>
 
-  <p>
-    Om det føles behov for det, kan vi fint finne på flere sosiale aktiviteter sammen for å føle på
-    et forhåpentligvis voksende samhold og verdigrunnlag.
-  </p>
-  <h3 id="invitasjon">Invitasjon (bli med)</h3>
-  <p>
-    Har både du og vi en god følelse etter datingen, får du en invitasjon til å bli med på
-    prosjektet vårt. Invitasjonen består av en arbeidskontrakt, aksjekjøpsavtale og aksjonæravtale.
-    Vi tenker med andre ord at du er et glimrende tilskudd til flokken, og vil gjerne ha deg med på
-    reisen.
-  </p>
-  <p>Se også [kynd.no/join](https://kynd.no/join).</p>
+Om det føles behov for det, kan vi fint finne på flere sosiale aktiviteter sammen for å føle på et
+forhåpentligvis voksende samhold og verdigrunnlag.
+
+<h3 id="invitasjon">Invitasjon (bli med)</h3>
+Har både du og vi en god følelse etter datingen, får du en invitasjon til å bli med på prosjektet
+vårt. Invitasjonen består av en arbeidskontrakt, aksjekjøpsavtale og aksjonæravtale. Vi tenker med
+andre ord at du er et glimrende tilskudd til flokken, og vil gjerne ha deg med på reisen.
+
+Se også [kynd.no/join](https://kynd.no/join).
+
 </Prose>

--- a/src/content/handbook/12-ordliste.mdx
+++ b/src/content/handbook/12-ordliste.mdx
@@ -6,23 +6,21 @@ order: 12
 import Prose from '@/components/Prose.astro';
 
 <Prose align="left" wide="true">
-  <p>
-    <ul>
-      <li>Kompanjong: ansatt og medeier.</li>
-      <li>Forkynd: ukentlig styremøte, åpent for alle.</li>
-      <li>Genvors: generalforsamling.</li>
-      <li>Daglig tjener: daglig leder.</li>
-      <li>Dating: rekrutteringsprosess.</li>
-      <li>Pitch: lita redegjørelse for hva du vil, f.eks. konferanse, kurs eller sertifisering.</li>
-      <li>
-        Annerledesdager: arbeidstid vi bruker på ikke-fakturerbare aktiviter som produkttid,
-        strategisamlinger, konferanser, etc.
-      </li>
-      <li>
-        LTM: Los Tacos Miles. Løpeversjonen av Tom Waitz, hvor man løper fra Los Tacos til Los Tacos
-        i Oslo og tar en enhet av eget valg på hvert stopp. Kynd sponser og er med-arrangør med Los
-        Tacos Norge og et knippe gode venner.
-      </li>
-    </ul>
-  </p>
+  <ul>
+    <li>Kompanjong: ansatt og medeier.</li>
+    <li>Forkynd: ukentlig styremøte, åpent for alle.</li>
+    <li>Genvors: generalforsamling.</li>
+    <li>Daglig tjener: daglig leder.</li>
+    <li>Dating: rekrutteringsprosess.</li>
+    <li>Pitch: lita redegjørelse for hva du vil, f.eks. konferanse, kurs eller sertifisering.</li>
+    <li>
+      Annerledesdager: arbeidstid vi bruker på ikke-fakturerbare aktiviter som produkttid,
+      strategisamlinger, konferanser, etc.
+    </li>
+    <li>
+      LTM: Los Tacos Miles. Løpeversjonen av Tom Waitz, hvor man løper fra Los Tacos til Los Tacos i
+      Oslo og tar en enhet av eget valg på hvert stopp. Kynd sponser og er med-arrangør med Los
+      Tacos Norge og et knippe gode venner.
+    </li>
+  </ul>
 </Prose>


### PR DESCRIPTION
## Summary
- add `postcss-nesting` in the PostCSS pipeline so component CSS nesting is compiled instead of relying on runtime nesting support
- flatten `src/components/Prose.astro` selector structure to reduce rendering variance in embedded browsers while preserving existing prose behavior
- normalize handbook MDX prose blocks to remove redundant JSX paragraph wrappers and prevent invalid nested paragraph output

## Test plan
- [x] `pnpm astro:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] `pnpm build`
- [x] verify no `<p><p>` nesting in `/bok` dev HTML output
- [x] verify compiled Prose CSS includes explicit `ul/ol` list-style restoration and `h3` rules
- [ ] manual browser verification in Cursor Browser, Safari, Arc, and Zen on `/bok`


Made with [Cursor](https://cursor.com)